### PR TITLE
Integration management

### DIFF
--- a/docs/superpowers/plans/2026-03-15-integration-management.md
+++ b/docs/superpowers/plans/2026-03-15-integration-management.md
@@ -1,0 +1,1464 @@
+# Integration Management Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add comprehensive integration management — a list page, a management page with metadata editing and token management, and a new View role — to HyperionCS.
+
+**Architecture:** Backend-first: amend the data model and add new FastAPI endpoints, then regenerate the frontend query client, then build the frontend pages. All backend endpoints live in the existing `integrations_router`. The frontend follows the established patterns from the currencies pages.
+
+**Tech Stack:** Python/FastAPI/SQLAlchemy/Alembic (backend), React/TanStack Router/TanStack Query/HeroUI/@tanstack/react-form (frontend), `@openapi-codegen` for client generation.
+
+**Spec:** `docs/superpowers/specs/2026-03-15-integration-management-design.md`
+
+---
+
+## File Map
+
+**Backend — modified:**
+- `hyperioncs/db/models/integration_permission.py` — add `View` role and `IntegrationActionRoles.View`
+- `hyperioncs/db/models/integration_token.py` — add `name: Mapped[str]` field
+- `hyperioncs/migrations/versions/781cb27e06c3_create_integration_token_model.py` — amend to include `name` column
+- `hyperioncs/schemas/integrations.py` — add `IntegrationTokenSchema`, `CreatedIntegrationTokenSchema`
+- `hyperioncs/api/app/schemas/integrations.py` — add `EditIntegrationSchema`, `CreateIntegrationTokenSchema`
+- `hyperioncs/api/app/routers/integrations.py` — add 6 new endpoints, extend list endpoint
+
+**Frontend — modified:**
+- `frontend/src/routes/__root.tsx` — add Integrations navbar link
+
+**Frontend — created:**
+- `frontend/src/routes/integrations/index.tsx` — integrations list page
+- `frontend/src/routes/integrations/$integrationId/manage.tsx` — integration management page
+
+**Frontend — modified:**
+- `frontend/src/routes/integrations/create.tsx` — redirect to list after creation
+
+---
+
+## Chunk 1: Backend — Data Model & Schemas
+
+### Task 1: Add `View` role to `IntegrationRole`
+
+**Files:**
+- Modify: `hyperioncs/db/models/integration_permission.py`
+
+- [ ] **Open `hyperioncs/db/models/integration_permission.py` and add the `View` role.**
+
+  Replace the file with:
+
+  ```python
+  import enum
+  from typing import TYPE_CHECKING
+
+  from sqlalchemy import ForeignKey
+  from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+  from hyperioncs.db import Base
+  from hyperioncs.db.models.utils import default_uuid_str
+
+  if TYPE_CHECKING:
+      from .integration import Integration
+
+
+  class IntegrationRole(enum.Enum):
+      Owner = "owner"
+      View = "view"
+
+
+  class IntegrationActionRoles:
+      Edit = [IntegrationRole.Owner]
+      Connect = [IntegrationRole.Owner]
+      View = [IntegrationRole.View, IntegrationRole.Owner]
+
+
+  class IntegrationPermission(Base):
+      __tablename__ = "integration_permissions"
+
+      id: Mapped[str] = mapped_column(primary_key=True, default=default_uuid_str)
+      user_id: Mapped[str]
+      integration_id: Mapped[str] = mapped_column(
+          ForeignKey("integrations.id", ondelete="CASCADE")
+      )
+      integration: Mapped["Integration"] = relationship(lazy="raise")
+
+      role: Mapped[IntegrationRole]
+  ```
+
+- [ ] **Verify the import still works:**
+
+  ```bash
+  uv run python -c "from hyperioncs.db.models.integration_permission import IntegrationRole, IntegrationActionRoles; print(IntegrationActionRoles.View)"
+  ```
+
+  Expected: `[<IntegrationRole.View: 'view'>, <IntegrationRole.Owner: 'owner'>]`
+
+- [ ] **Commit:**
+
+  ```bash
+  git add hyperioncs/db/models/integration_permission.py
+  git commit -m "feat: add View role to IntegrationRole"
+  ```
+
+---
+
+### Task 2: Add `name` to `IntegrationToken` model and amend migration
+
+**Files:**
+- Modify: `hyperioncs/db/models/integration_token.py`
+- Modify: `hyperioncs/migrations/versions/781cb27e06c3_create_integration_token_model.py`
+
+- [ ] **Update `hyperioncs/db/models/integration_token.py` to add `name`:**
+
+  ```python
+  from typing import TYPE_CHECKING
+
+  from sqlalchemy import ForeignKey
+  from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+  from hyperioncs.db import Base
+  from hyperioncs.db.models.utils import default_uuid_str
+
+  if TYPE_CHECKING:
+      from .integration import Integration
+
+
+  class IntegrationToken(Base):
+      __tablename__ = "integration_tokens"
+
+      id: Mapped[str] = mapped_column(primary_key=True, default=default_uuid_str)
+      integration_id: Mapped[str] = mapped_column(
+          ForeignKey("integrations.id", ondelete="CASCADE")
+      )
+      name: Mapped[str]
+
+      integration: Mapped["Integration"] = relationship(lazy="raise")
+  ```
+
+- [ ] **Amend `hyperioncs/migrations/versions/781cb27e06c3_create_integration_token_model.py` to include the `name` column:**
+
+  ```python
+  """Create integration token model
+
+  Revision ID: 781cb27e06c3
+  Revises: 97118cf7629a
+  Create Date: 2025-12-29 18:03:43.785881
+
+  """
+
+  from typing import Sequence, Union
+
+  import sqlalchemy as sa
+  from alembic import op
+
+  # revision identifiers, used by Alembic.
+  revision: str = "781cb27e06c3"
+  down_revision: Union[str, Sequence[str], None] = "97118cf7629a"
+  branch_labels: Union[str, Sequence[str], None] = None
+  depends_on: Union[str, Sequence[str], None] = None
+
+
+  def upgrade() -> None:
+      op.create_table(
+          "integration_tokens",
+          sa.Column("id", sa.String(), nullable=False),
+          sa.Column("integration_id", sa.String(), nullable=False),
+          sa.Column("name", sa.String(), nullable=False),
+          sa.ForeignKeyConstraint(
+              ["integration_id"],
+              ["integrations.id"],
+              name=op.f("fk_integration_tokens_integration_id_integrations"),
+              ondelete="CASCADE",
+          ),
+          sa.PrimaryKeyConstraint("id", name=op.f("pk_integration_tokens")),
+      )
+
+
+  def downgrade() -> None:
+      op.drop_table("integration_tokens")
+  ```
+
+- [ ] **Delete the existing database and re-run migrations** (no production data):
+
+  ```bash
+  rm -f hyperion.sqlite
+  uv run python -m hyperioncs upgrade
+  ```
+
+  Expected: migration runs without error.
+
+- [ ] **Commit:**
+
+  ```bash
+  git add hyperioncs/db/models/integration_token.py hyperioncs/migrations/versions/781cb27e06c3_create_integration_token_model.py
+  git commit -m "feat: add name to IntegrationToken model"
+  ```
+
+---
+
+### Task 3: Add new Pydantic schemas
+
+**Files:**
+- Modify: `hyperioncs/schemas/integrations.py`
+- Modify: `hyperioncs/api/app/schemas/integrations.py`
+
+- [ ] **Add `IntegrationTokenSchema` and `CreatedIntegrationTokenSchema` to `hyperioncs/schemas/integrations.py`:**
+
+  ```python
+  from pydantic import BaseModel, ConfigDict, Field
+
+
+  class IntegrationSchema(BaseModel):
+      model_config = ConfigDict(from_attributes=True)
+
+      id: str = Field(description="The unique identifier of the integration.")
+      name: str = Field(description="The name of the integration.")
+      description: str = Field(description="A description of the integration.")
+      url: str | None = Field(
+          default=None, description="URL to the website for the integration."
+      )
+      private: bool = Field(description="Whether the integration is private.")
+
+
+  class IntegrationTokenSchema(BaseModel):
+      model_config = ConfigDict(from_attributes=True)
+
+      id: str = Field(description="The unique identifier of the token.")
+      name: str = Field(description="The name of the token.")
+
+
+  class CreatedIntegrationTokenSchema(BaseModel):
+      model_config = ConfigDict(from_attributes=True)
+
+      id: str = Field(description="The unique identifier of the token.")
+      name: str = Field(description="The name of the token.")
+      token: str = Field(description="The JWT token value. Only returned at creation time.")
+  ```
+
+- [ ] **Add `EditIntegrationSchema` and `CreateIntegrationTokenSchema` to `hyperioncs/api/app/schemas/integrations.py`:**
+
+  ```python
+  from pydantic import BaseModel, Field
+
+  from hyperioncs.schemas import NullableString
+
+
+  class CreateIntegrationSchema(BaseModel):
+      name: str = Field(description="The name of the integration.")
+      description: str = Field(description="A description of the integration.")
+      url: NullableString = Field(
+          default=None, description="URL to the website for the integration."
+      )
+
+
+  class ConnectIntegrationSchema(BaseModel):
+      currency_shortcode: str = Field(
+          description="The shortcode of the currency to connect the integration to."
+      )
+
+
+  class EditIntegrationSchema(BaseModel):
+      name: str = Field(description="The name of the integration.")
+      description: str = Field(description="A description of the integration.")
+      url: NullableString = Field(description="URL to the website for the integration.")
+
+
+  class CreateIntegrationTokenSchema(BaseModel):
+      name: str = Field(description="The name of the token.")
+  ```
+
+  Note: `EditIntegrationSchema.url` has **no default** — all three fields are required.
+
+- [ ] **Verify imports work:**
+
+  ```bash
+  uv run python -c "from hyperioncs.api.app.schemas.integrations import EditIntegrationSchema, CreateIntegrationTokenSchema; from hyperioncs.schemas.integrations import IntegrationTokenSchema, CreatedIntegrationTokenSchema; print('ok')"
+  ```
+
+  Expected: `ok`
+
+- [ ] **Commit:**
+
+  ```bash
+  git add hyperioncs/schemas/integrations.py hyperioncs/api/app/schemas/integrations.py
+  git commit -m "feat: add integration token and edit schemas"
+  ```
+
+---
+
+## Chunk 2: Backend — API Endpoints
+
+### Task 4: Extend `list_integrations` with `manageable` param
+
+**Files:**
+- Modify: `hyperioncs/api/app/routers/integrations.py`
+
+- [ ] **Update the `list_integrations` function signature and body.** Add `manageable: bool = False` as a `Query` param. When `True`, inner-join on Edit role instead of the existing outer-join/public logic.
+
+  Replace the existing `list_integrations` function with:
+
+  ```python
+  @integrations_router.get("/", response_model=list[IntegrationSchema])
+  async def list_integrations(
+      manageable: bool = Query(False),
+      db: AsyncSession = Depends(get_db),
+      current_user: SessionUser = Depends(require_session_user),
+  ):
+      """List integrations visible to the current user.
+
+      When manageable=true, returns only integrations the user can edit.
+      Otherwise returns public integrations and integrations the user can connect.
+      """
+      if manageable:
+          return (
+              (
+                  await db.execute(
+                      select(Integration).join(
+                          IntegrationPermission,
+                          and_(
+                              IntegrationPermission.user_id == current_user.id,
+                              IntegrationPermission.integration_id == Integration.id,
+                              IntegrationPermission.role.in_(IntegrationActionRoles.Edit),
+                          ),
+                      )
+                  )
+              )
+              .scalars()
+              .all()
+          )
+
+      return (
+          (
+              await db.execute(
+                  select(Integration)
+                  .join(
+                      IntegrationPermission,
+                      and_(
+                          IntegrationPermission.user_id == current_user.id,
+                          IntegrationPermission.integration_id == Integration.id,
+                          IntegrationPermission.role.in_(IntegrationActionRoles.Connect),
+                      ),
+                      isouter=True,
+                  )
+                  .filter(
+                      or_(not_(Integration.private), IntegrationPermission.id.isnot(None))
+                  )
+              )
+          )
+          .scalars()
+          .all()
+      )
+  ```
+
+  Also add `Query` to the FastAPI imports at the top of the file:
+
+  ```python
+  from fastapi import APIRouter, Depends, Query, status
+  ```
+
+- [ ] **Verify the server starts and the endpoint appears in OpenAPI docs:**
+
+  ```bash
+  uv run python -m hyperioncs start
+  ```
+
+  Navigate to `http://localhost:8000/docs` and confirm `GET /api/internal/integrations/` now shows a `manageable` query param.
+
+- [ ] **Commit:**
+
+  ```bash
+  git add hyperioncs/api/app/routers/integrations.py
+  git commit -m "feat: add manageable filter to list integrations endpoint"
+  ```
+
+---
+
+### Task 5: Add `get_integration` endpoint
+
+> **Depends on Task 1** — `IntegrationActionRoles.View` must exist before this endpoint will work.
+
+**Files:**
+- Modify: `hyperioncs/api/app/routers/integrations.py`
+
+- [ ] **Add the `get_integration` function after the `list_integrations` function.** No import changes are needed — `IntegrationActionRoles`, `IntegrationPermission`, and `IntegrationRole` are already imported.
+
+  Add the endpoint after `list_integrations`:
+
+  ```python
+  @integrations_router.get(
+      "/{integration_id}",
+      response_model=IntegrationSchema,
+      responses={
+          status.HTTP_403_FORBIDDEN: {
+              "description": "Unauthorized",
+              "model": ErrorResponseSchema,
+          }
+      },
+  )
+  async def get_integration(
+      integration_id: str,
+      db: AsyncSession = Depends(get_db),
+      current_user: SessionUser = Depends(require_session_user),
+  ):
+      """Get a single integration visible to the current user.
+
+      Public integrations are accessible to all authenticated users.
+      Private integrations require the View role.
+      """
+      integration = (
+          await db.execute(
+              select(Integration)
+              .filter_by(id=integration_id)
+              .join(
+                  IntegrationPermission,
+                  and_(
+                      IntegrationPermission.user_id == current_user.id,
+                      IntegrationPermission.integration_id == Integration.id,
+                      IntegrationPermission.role.in_(IntegrationActionRoles.View),
+                  ),
+                  isouter=True,
+              )
+              .filter(
+                  or_(not_(Integration.private), IntegrationPermission.id.isnot(None))
+              )
+          )
+      ).scalar_one_or_none()
+
+      if not integration:
+          return JSONResponse(
+              status_code=status.HTTP_403_FORBIDDEN,
+              content=ErrorResponseSchema(
+                  detail="The requested integration could not be found or you do not have permission to view it."
+              ).model_dump(),
+          )
+
+      return integration
+  ```
+
+- [ ] **Verify the endpoint appears in OpenAPI docs at `GET /api/internal/integrations/{integration_id}`.**
+
+- [ ] **Commit:**
+
+  ```bash
+  git add hyperioncs/api/app/routers/integrations.py
+  git commit -m "feat: add get_integration endpoint"
+  ```
+
+---
+
+### Task 6: Add `edit_integration` endpoint
+
+**Files:**
+- Modify: `hyperioncs/api/app/routers/integrations.py`
+
+- [ ] **Add the required import for `EditIntegrationSchema`** to the imports at the top of `integrations.py`:
+
+  ```python
+  from hyperioncs.api.app.schemas.integrations import (
+      ConnectIntegrationSchema,
+      CreateIntegrationSchema,
+      EditIntegrationSchema,
+  )
+  ```
+
+- [ ] **Add the `edit_integration` function after `get_integration`:**
+
+  ```python
+  @integrations_router.patch(
+      "/{integration_id}",
+      response_model=IntegrationSchema,
+      responses={
+          status.HTTP_403_FORBIDDEN: {
+              "description": "Unauthorized",
+              "model": ErrorResponseSchema,
+          }
+      },
+  )
+  async def edit_integration(
+      integration_id: str,
+      body: EditIntegrationSchema,
+      db: AsyncSession = Depends(get_db),
+      current_user: SessionUser = Depends(require_session_user),
+  ):
+      """Edit an integration's metadata. Requires Edit role."""
+      async with db.begin():
+          integration = (
+              await db.execute(
+                  select(Integration)
+                  .filter_by(id=integration_id)
+                  .join(
+                      IntegrationPermission,
+                      and_(
+                          IntegrationPermission.user_id == current_user.id,
+                          IntegrationPermission.integration_id == Integration.id,
+                          IntegrationPermission.role.in_(IntegrationActionRoles.Edit),
+                      ),
+                  )
+              )
+          ).scalar_one_or_none()
+
+          if not integration:
+              return JSONResponse(
+                  status_code=status.HTTP_403_FORBIDDEN,
+                  content=ErrorResponseSchema(
+                      detail="The requested integration could not be found or you do not have permission to edit it."
+                  ).model_dump(),
+              )
+
+          integration.name = body.name
+          integration.description = body.description
+          integration.url = body.url
+
+          await db.commit()
+
+          return integration
+  ```
+
+- [ ] **Verify endpoint appears in OpenAPI docs at `PATCH /api/internal/integrations/{integration_id}`.**
+
+- [ ] **Commit:**
+
+  ```bash
+  git add hyperioncs/api/app/routers/integrations.py
+  git commit -m "feat: add edit_integration endpoint"
+  ```
+
+---
+
+### Task 7: Add token endpoints
+
+> **Depends on Tasks 1 and 2** — `IntegrationActionRoles.Edit` must exist and `IntegrationToken.name` must be in the model/migration.
+
+**Files:**
+- Modify: `hyperioncs/api/app/routers/integrations.py`
+
+- [ ] **Add the required imports** to the top of `integrations.py`. Make these changes to the existing import block — do not add duplicate import statements:
+
+  1. Add `import jwt` near the top (with other stdlib/third-party imports).
+  2. Add `from hyperioncs.config import config`.
+  3. Add `from hyperioncs.db.models.integration_token import IntegrationToken`.
+  4. Expand the existing `from hyperioncs.api.app.schemas.integrations import (...)` to include `CreateIntegrationTokenSchema` (it should already have `ConnectIntegrationSchema`, `CreateIntegrationSchema`, and after Task 6 `EditIntegrationSchema`).
+  5. Expand the existing `from hyperioncs.schemas.integrations import IntegrationSchema` to also import `CreatedIntegrationTokenSchema` and `IntegrationTokenSchema`:
+
+  ```python
+  from hyperioncs.schemas.integrations import (
+      CreatedIntegrationTokenSchema,
+      IntegrationSchema,
+      IntegrationTokenSchema,
+  )
+  ```
+
+  The final imports block at the top of the file should contain exactly one import per module — no duplicates.
+
+- [ ] **Add `list_integration_tokens` after the `edit_integration` function:**
+
+  ```python
+  @integrations_router.get(
+      "/{integration_id}/tokens",
+      response_model=list[IntegrationTokenSchema],
+      responses={
+          status.HTTP_403_FORBIDDEN: {
+              "description": "Unauthorized",
+              "model": ErrorResponseSchema,
+          }
+      },
+  )
+  async def list_integration_tokens(
+      integration_id: str,
+      db: AsyncSession = Depends(get_db),
+      current_user: SessionUser = Depends(require_session_user),
+  ):
+      """List tokens for an integration. Requires Edit role."""
+      integration = (
+          await db.execute(
+              select(Integration)
+              .filter_by(id=integration_id)
+              .join(
+                  IntegrationPermission,
+                  and_(
+                      IntegrationPermission.user_id == current_user.id,
+                      IntegrationPermission.integration_id == Integration.id,
+                      IntegrationPermission.role.in_(IntegrationActionRoles.Edit),
+                  ),
+              )
+          )
+      ).scalar_one_or_none()
+
+      if not integration:
+          return JSONResponse(
+              status_code=status.HTTP_403_FORBIDDEN,
+              content=ErrorResponseSchema(
+                  detail="The requested integration could not be found or you do not have permission to manage its tokens."
+              ).model_dump(),
+          )
+
+      return (
+          (
+              await db.execute(
+                  select(IntegrationToken).filter_by(integration_id=integration.id)
+              )
+          )
+          .scalars()
+          .all()
+      )
+  ```
+
+- [ ] **Add `create_integration_token` after `list_integration_tokens`:**
+
+  ```python
+  @integrations_router.post(
+      "/{integration_id}/tokens",
+      status_code=status.HTTP_201_CREATED,
+      response_model=CreatedIntegrationTokenSchema,
+      responses={
+          status.HTTP_403_FORBIDDEN: {
+              "description": "Unauthorized",
+              "model": ErrorResponseSchema,
+          }
+      },
+  )
+  async def create_integration_token(
+      integration_id: str,
+      body: CreateIntegrationTokenSchema,
+      db: AsyncSession = Depends(get_db),
+      current_user: SessionUser = Depends(require_session_user),
+  ):
+      """Create a new token for an integration. Requires Edit role.
+
+      The token value is only returned in this response — it cannot be retrieved later.
+      """
+      async with db.begin():
+          integration = (
+              await db.execute(
+                  select(Integration)
+                  .filter_by(id=integration_id)
+                  .join(
+                      IntegrationPermission,
+                      and_(
+                          IntegrationPermission.user_id == current_user.id,
+                          IntegrationPermission.integration_id == Integration.id,
+                          IntegrationPermission.role.in_(IntegrationActionRoles.Edit),
+                      ),
+                  )
+              )
+          ).scalar_one_or_none()
+
+          if not integration:
+              return JSONResponse(
+                  status_code=status.HTTP_403_FORBIDDEN,
+                  content=ErrorResponseSchema(
+                      detail="The requested integration could not be found or you do not have permission to manage its tokens."
+                  ).model_dump(),
+              )
+
+          token_id = default_uuid_str()
+          new_token = IntegrationToken(
+              id=token_id,
+              integration_id=integration.id,
+              name=body.name,
+          )
+          db.add(new_token)
+          await db.commit()
+
+      token_value = jwt.encode(
+          {"token_id": token_id},
+          config.jwt_secret,
+          algorithm=config.jwt_algorithm,
+      )
+
+      return CreatedIntegrationTokenSchema(
+          id=token_id,
+          name=body.name,
+          token=token_value,
+      )
+  ```
+
+- [ ] **Add `delete_integration_token` after `create_integration_token`:**
+
+  ```python
+  @integrations_router.delete(
+      "/{integration_id}/tokens/{token_id}",
+      status_code=status.HTTP_202_ACCEPTED,
+      responses={
+          status.HTTP_403_FORBIDDEN: {
+              "description": "Unauthorized",
+              "model": ErrorResponseSchema,
+          },
+          status.HTTP_404_NOT_FOUND: {
+              "description": "Token Not Found",
+              "model": ErrorResponseSchema,
+          },
+      },
+  )
+  async def delete_integration_token(
+      integration_id: str,
+      token_id: str,
+      db: AsyncSession = Depends(get_db),
+      current_user: SessionUser = Depends(require_session_user),
+  ):
+      """Delete an integration token. Requires Edit role."""
+      async with db.begin():
+          integration = (
+              await db.execute(
+                  select(Integration)
+                  .filter_by(id=integration_id)
+                  .join(
+                      IntegrationPermission,
+                      and_(
+                          IntegrationPermission.user_id == current_user.id,
+                          IntegrationPermission.integration_id == Integration.id,
+                          IntegrationPermission.role.in_(IntegrationActionRoles.Edit),
+                      ),
+                  )
+              )
+          ).scalar_one_or_none()
+
+          if not integration:
+              return JSONResponse(
+                  status_code=status.HTTP_403_FORBIDDEN,
+                  content=ErrorResponseSchema(
+                      detail="The requested integration could not be found or you do not have permission to manage its tokens."
+                  ).model_dump(),
+              )
+
+          token = (
+              await db.execute(
+                  select(IntegrationToken).filter_by(
+                      id=token_id, integration_id=integration.id
+                  )
+              )
+          ).scalar_one_or_none()
+
+          if not token:
+              return JSONResponse(
+                  status_code=status.HTTP_404_NOT_FOUND,
+                  content=ErrorResponseSchema(
+                      detail="The requested token could not be found."
+                  ).model_dump(),
+              )
+
+          await db.delete(token)
+          await db.commit()
+
+      return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content={})
+  ```
+
+- [ ] **Verify the server starts cleanly:**
+
+  ```bash
+  uv run python -m hyperioncs start
+  ```
+
+  Check `http://localhost:8000/docs` — confirm all 6 new endpoints appear under `Integrations`:
+  - `GET /api/internal/integrations/` (with `manageable` param)
+  - `GET /api/internal/integrations/{integration_id}`
+  - `PATCH /api/internal/integrations/{integration_id}`
+  - `GET /api/internal/integrations/{integration_id}/tokens`
+  - `POST /api/internal/integrations/{integration_id}/tokens`
+  - `DELETE /api/internal/integrations/{integration_id}/tokens/{token_id}`
+
+- [ ] **Commit:**
+
+  ```bash
+  git add hyperioncs/api/app/routers/integrations.py
+  git commit -m "feat: add token management endpoints"
+  ```
+
+---
+
+## Chunk 3: Frontend
+
+### Task 8: Regenerate the frontend query client
+
+**Files:**
+- Regenerated: `frontend/src/queries/internal/internalComponents.ts` (and other files in that directory)
+
+- [ ] **Run the codegen from the project root** (the server must be running for this to work — start it first if it isn't):
+
+  ```bash
+  npm run gen-openapi
+  ```
+
+  Expected: no errors; files under `frontend/src/queries/internal/` and `frontend/src/queries/integrations/v1/` are updated.
+
+- [ ] **Verify the new hooks are available:**
+
+  ```bash
+  grep -n "getIntegrationQuery\|listIntegrationTokensQuery\|useCreateIntegrationToken\|useDeleteIntegrationToken\|useEditIntegration" frontend/src/queries/internal/internalComponents.ts | head -20
+  ```
+
+  Expected: all five names appear.
+
+- [ ] **Commit:**
+
+  ```bash
+  git add frontend/src/queries/
+  git commit -m "chore: regenerate frontend query client"
+  ```
+
+---
+
+### Task 9: Add Integrations navbar link
+
+**Files:**
+- Modify: `frontend/src/routes/__root.tsx`
+
+- [ ] **Add the Integrations `NavbarItem` before the Currencies one in `__root.tsx`:**
+
+  ```tsx
+  <NavbarItem>
+    <Link to="/integrations" color="foreground">
+      Integrations
+    </Link>
+  </NavbarItem>
+  <NavbarItem>
+    <Link to="/currencies" color="foreground">
+      Currencies
+    </Link>
+  </NavbarItem>
+  ```
+
+- [ ] **Commit:**
+
+  ```bash
+  git add frontend/src/routes/__root.tsx
+  git commit -m "feat: add Integrations navbar link"
+  ```
+
+---
+
+### Task 10: Create the integrations list page
+
+**Files:**
+- Create: `frontend/src/routes/integrations/index.tsx`
+
+- [ ] **Create `frontend/src/routes/integrations/index.tsx`:**
+
+  ```tsx
+  import { Button } from '@heroui/react';
+  import { createFileRoute } from '@tanstack/react-router';
+
+  import { Link } from '@/components/link';
+  import { queryClient } from '@/lib/query';
+  import { useStore } from '@/lib/state';
+  import {
+    listIntegrationsQuery,
+    useSuspenseListIntegrations,
+  } from '@/queries/internal/internalComponents';
+
+  export const Route = createFileRoute('/integrations/')({
+    component: RouteComponent,
+    loader: () =>
+      queryClient.ensureQueryData(
+        listIntegrationsQuery({ queryParams: { manageable: true } }),
+      ),
+  });
+
+  function RouteComponent() {
+    const { data: integrations } = useSuspenseListIntegrations({
+      queryParams: { manageable: true },
+    });
+    const user = useStore((state) => state.user);
+
+    return (
+      <div>
+        <div className="flex flex-row justify-between">
+          <h1 className="text-xl font-bold">Integrations</h1>
+          {user && (
+            <Button as={Link} to="/integrations/create">
+              Create Integration
+            </Button>
+          )}
+        </div>
+        <div>
+          {integrations.map((integration) => (
+            <div key={integration.id}>
+              <Link
+                to="/integrations/$integrationId/manage"
+                params={{ integrationId: integration.id }}
+                color="foreground"
+              >
+                <span className="font-semibold">{integration.name}</span>
+                {integration.description && (
+                  <span className="text-default-500 ml-2 text-sm">
+                    {integration.description}
+                  </span>
+                )}
+              </Link>
+            </div>
+          ))}
+          {integrations.length === 0 && (
+            <p className="text-default-400 w-full text-center italic">
+              No integrations yet.
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+  ```
+
+- [ ] **Verify the page renders** by navigating to `http://localhost:5173/integrations` (run `npm run dev` if not already running). Confirm an empty list with "No integrations yet." and a "Create Integration" button when logged in.
+
+- [ ] **Commit:**
+
+  ```bash
+  git add frontend/src/routes/integrations/index.tsx
+  git commit -m "feat: add integrations list page"
+  ```
+
+---
+
+### Task 11: Create the integration management page
+
+**Files:**
+- Create: `frontend/src/routes/integrations/$integrationId/manage.tsx`
+
+- [ ] **Create `frontend/src/routes/integrations/$integrationId/manage.tsx`:**
+
+  ```tsx
+  import { Alert, Button, Form, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from '@heroui/react';
+  import { useForm } from '@tanstack/react-form';
+  import { createFileRoute } from '@tanstack/react-router';
+  import { useState } from 'react';
+  import z from 'zod';
+
+  import { queryClient } from '@/lib/query';
+  import {
+    getIntegrationQuery,
+    listIntegrationTokensQuery,
+    useCreateIntegrationToken,
+    useDeleteIntegrationToken,
+    useEditIntegration,
+    useSuspenseGetIntegration,
+    useSuspenseListIntegrationTokens,
+  } from '@/queries/internal/internalComponents';
+  import type {
+    ErrorResponseSchema,
+    IntegrationTokenSchema,
+  } from '@/queries/internal/internalSchemas';
+  import {
+    CreateIntegrationTokenSchemaZod,
+    EditIntegrationSchemaZod,
+  } from '@/queries/internal/internalSchemas.zod';
+
+  export const Route = createFileRoute('/integrations/$integrationId/manage')({
+    component: RouteComponent,
+    loader: ({ params: { integrationId } }) =>
+      Promise.all([
+        queryClient.ensureQueryData(
+          getIntegrationQuery({ pathParams: { integrationId } }),
+        ),
+        queryClient.ensureQueryData(
+          listIntegrationTokensQuery({ pathParams: { integrationId } }),
+        ),
+      ]),
+  });
+
+  function EditIntegrationDetails({ integrationId }: { integrationId: string }) {
+    const { data: integration } = useSuspenseGetIntegration({
+      pathParams: { integrationId },
+    });
+    const { mutateAsync: editIntegration, isPending, data } = useEditIntegration();
+
+    async function handleSubmit(
+      value: z.infer<typeof EditIntegrationSchemaZod>,
+    ) {
+      try {
+        await editIntegration({ pathParams: { integrationId }, body: value });
+        await queryClient.invalidateQueries(
+          getIntegrationQuery({ pathParams: { integrationId } }),
+        );
+      } catch (error) {
+        form.setErrorMap({
+          onSubmit: {
+            fields: {},
+            form: (error as ErrorResponseSchema).detail,
+          },
+        });
+      }
+    }
+
+    const form = useForm({
+      defaultValues: {
+        name: integration.name,
+        description: integration.description,
+        url: integration.url ?? '',
+      } as z.infer<typeof EditIntegrationSchemaZod>,
+      onSubmit: ({ value }) => handleSubmit(value),
+      validators: { onSubmit: EditIntegrationSchemaZod },
+    });
+
+    return (
+      <div>
+        <h2 className="text-2xl font-semibold">Edit Integration Details</h2>
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+            form.handleSubmit();
+          }}
+        >
+          <form.Field
+            name="name"
+            children={(field) => (
+              <Input
+                name={field.name}
+                isRequired
+                label="Name"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+                validationBehavior="aria"
+                errorMessage={field.state.meta.errors
+                  .filter((e) => e !== undefined)
+                  .map((e) => e.message)
+                  .join(', ')}
+                isInvalid={!field.state.meta.isValid}
+              />
+            )}
+          />
+          <form.Field
+            name="description"
+            children={(field) => (
+              <Input
+                name={field.name}
+                isRequired
+                label="Description"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+                validationBehavior="aria"
+                errorMessage={field.state.meta.errors
+                  .filter((e) => e !== undefined)
+                  .map((e) => e.message)
+                  .join(', ')}
+                isInvalid={!field.state.meta.isValid}
+              />
+            )}
+          />
+          <form.Field
+            name="url"
+            children={(field) => (
+              <Input
+                name={field.name}
+                label="URL"
+                value={field.state.value || ''}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+                validationBehavior="aria"
+                errorMessage={field.state.meta.errors
+                  .filter((e) => e !== undefined)
+                  .map((e) => e.message)
+                  .join(', ')}
+                isInvalid={!field.state.meta.isValid}
+              />
+            )}
+          />
+          <Button type="submit" isLoading={isPending}>
+            Save
+          </Button>
+          <form.Subscribe
+            selector={(state) => state.errors.filter((e) => typeof e === 'string')}
+            children={(errors) =>
+              errors.length > 0 && <Alert color="danger">{errors}</Alert>
+            }
+          />
+          {data && <Alert color="success">Integration updated!</Alert>}
+        </Form>
+      </div>
+    );
+  }
+
+  function TokenRow({
+    token,
+    integrationId,
+    onDeleteError,
+  }: {
+    token: IntegrationTokenSchema;
+    integrationId: string;
+    onDeleteError: (message: string) => void;
+  }) {
+    const { mutateAsync: deleteToken } = useDeleteIntegrationToken();
+
+    async function handleDelete() {
+      try {
+        await deleteToken({
+          pathParams: { integrationId, tokenId: token.id },
+        });
+        await queryClient.invalidateQueries(
+          listIntegrationTokensQuery({ pathParams: { integrationId } }),
+        );
+      } catch (error) {
+        onDeleteError((error as ErrorResponseSchema).detail);
+      }
+    }
+
+    return (
+      <div className="flex w-full items-center justify-between">
+        <span>{token.name}</span>
+        <Button color="danger" onPress={handleDelete}>
+          Delete
+        </Button>
+      </div>
+    );
+  }
+
+  function ManageTokens({ integrationId }: { integrationId: string }) {
+    const { data: tokens } = useSuspenseListIntegrationTokens({
+      pathParams: { integrationId },
+    });
+    const { mutateAsync: createToken, isPending } = useCreateIntegrationToken();
+
+    const [showCreateForm, setShowCreateForm] = useState(false);
+    const [newTokenValue, setNewTokenValue] = useState<string | null>(null);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
+
+    async function handleCreateSubmit(
+      value: z.infer<typeof CreateIntegrationTokenSchemaZod>,
+    ) {
+      try {
+        const result = await createToken({
+          pathParams: { integrationId },
+          body: value,
+        });
+        setShowCreateForm(false);
+        form.reset();
+        await queryClient.invalidateQueries(
+          listIntegrationTokensQuery({ pathParams: { integrationId } }),
+        );
+        setNewTokenValue(result.token);
+      } catch (error) {
+        form.setErrorMap({
+          onSubmit: {
+            fields: {},
+            form: (error as ErrorResponseSchema).detail,
+          },
+        });
+      }
+    }
+
+    const form = useForm({
+      defaultValues: { name: '' } as z.infer<
+        typeof CreateIntegrationTokenSchemaZod
+      >,
+      onSubmit: ({ value }) => handleCreateSubmit(value),
+      validators: { onSubmit: CreateIntegrationTokenSchemaZod },
+    });
+
+    return (
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold">Manage Tokens</h2>
+
+        {deleteError && (
+          <Alert color="danger" onClose={() => setDeleteError(null)}>
+            {deleteError}
+          </Alert>
+        )}
+
+        <div className="space-y-1">
+          {tokens.length === 0 ? (
+            <p className="text-default-400 w-full text-center italic">
+              No tokens yet.
+            </p>
+          ) : (
+            tokens.map((token) => (
+              <TokenRow
+                key={token.id}
+                token={token}
+                integrationId={integrationId}
+                onDeleteError={setDeleteError}
+              />
+            ))
+          )}
+        </div>
+
+        <Button
+          onPress={() => {
+            setShowCreateForm((v) => !v);
+            form.reset();
+          }}
+        >
+          Create Token
+        </Button>
+
+        {showCreateForm && (
+          <Form
+            onSubmit={(e) => {
+              e.preventDefault();
+              form.handleSubmit();
+            }}
+          >
+            <form.Field
+              name="name"
+              children={(field) => (
+                <Input
+                  name={field.name}
+                  isRequired
+                  label="Token Name"
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  validationBehavior="aria"
+                  errorMessage={field.state.meta.errors
+                    .filter((e) => e !== undefined)
+                    .map((e) => e.message)
+                    .join(', ')}
+                  isInvalid={!field.state.meta.isValid}
+                />
+              )}
+            />
+            <Button type="submit" isLoading={isPending}>
+              Create
+            </Button>
+            <form.Subscribe
+              selector={(state) =>
+                state.errors.filter((e) => typeof e === 'string')
+              }
+              children={(errors) =>
+                errors.length > 0 && <Alert color="danger">{errors}</Alert>
+              }
+            />
+          </Form>
+        )}
+
+        <Modal
+          isOpen={newTokenValue !== null}
+          onClose={() => setNewTokenValue(null)}
+        >
+          <ModalContent>
+            <ModalHeader>Token Created</ModalHeader>
+            <ModalBody>
+              <Alert color="warning">
+                This token will not be shown again. Copy it now.
+              </Alert>
+              <Input
+                isReadOnly
+                label="Token"
+                value={newTokenValue ?? ''}
+                onClick={(e) => (e.target as HTMLInputElement).select()}
+              />
+            </ModalBody>
+            <ModalFooter>
+              <Button onPress={() => setNewTokenValue(null)}>Done</Button>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+      </div>
+    );
+  }
+
+  function RouteComponent() {
+    const { integrationId } = Route.useParams();
+
+    return (
+      <div className="space-y-8">
+        <EditIntegrationDetails integrationId={integrationId} />
+        <ManageTokens integrationId={integrationId} />
+      </div>
+    );
+  }
+  ```
+
+- [ ] **Verify the page builds without TypeScript errors:**
+
+  ```bash
+  npm run build
+  ```
+
+  Expected: no type errors.
+
+- [ ] **Manually verify the management page works** by creating an integration, navigating to `/integrations/{id}/manage`, editing details, creating a token (modal should appear with copyable value), and deleting a token.
+
+- [ ] **Commit:**
+
+  ```bash
+  git add frontend/src/routes/integrations/\$integrationId/
+  git commit -m "feat: add integration management page"
+  ```
+
+---
+
+### Task 12: Redirect `/integrations/create` after creation
+
+**Files:**
+- Modify: `frontend/src/routes/integrations/create.tsx`
+
+- [ ] **Update `create.tsx` to import `useNavigate` and redirect after creation instead of showing a success alert.**
+
+  Replace the `handleSubmit` function and remove the success alert:
+
+  ```tsx
+  import { Alert, Button, Form, Input } from '@heroui/react';
+  import { useForm } from '@tanstack/react-form';
+  import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
+  import z from 'zod';
+
+  import { queryClient } from '@/lib/query';
+  import { useStore } from '@/lib/state';
+  import {
+    listIntegrationsQuery,
+    useCreateIntegration,
+  } from '@/queries/internal/internalComponents';
+  import { ErrorResponseSchema } from '@/queries/internal/internalSchemas';
+  import { CreateIntegrationSchemaZod } from '@/queries/internal/internalSchemas.zod';
+
+  export const Route = createFileRoute('/integrations/create')({
+    component: RouteComponent,
+  });
+
+  function CreateIntegrationForm() {
+    const { mutateAsync: createIntegration, isPending } = useCreateIntegration();
+    const navigate = useNavigate();
+
+    async function handleSubmit(value: z.infer<typeof CreateIntegrationSchemaZod>) {
+      try {
+        await createIntegration({ body: value });
+        await queryClient.invalidateQueries(
+          listIntegrationsQuery({ queryParams: { manageable: true } }),
+        );
+        navigate({ to: '/integrations' });
+      } catch (error) {
+        form.setErrorMap({ onSubmit: { fields: {}, form: (error as ErrorResponseSchema).detail } });
+      }
+    }
+
+    const form = useForm({
+      defaultValues: {
+        name: '',
+        description: '',
+      } as z.infer<typeof CreateIntegrationSchemaZod>,
+      onSubmit: ({ value }) => handleSubmit(value),
+      validators: { onSubmit: CreateIntegrationSchemaZod },
+    });
+
+    return (
+      <Form
+        onSubmit={(e) => {
+          e.preventDefault();
+          form.handleSubmit();
+        }}
+      >
+        <form.Field
+          name="name"
+          children={(field) => (
+            <Input
+              name={field.name}
+              isRequired
+              label="Name"
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+              validationBehavior="aria"
+              errorMessage={field.state.meta.errors
+                .filter((e) => e !== undefined)
+                .map((e) => e.message)
+                .join(', ')}
+              isInvalid={!field.state.meta.isValid}
+            />
+          )}
+        />
+
+        <form.Field
+          name="description"
+          children={(field) => (
+            <Input
+              name={field.name}
+              isRequired
+              label="Description"
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+              validationBehavior="aria"
+              errorMessage={field.state.meta.errors
+                .filter((e) => e !== undefined)
+                .map((e) => e.message)
+                .join(', ')}
+              isInvalid={!field.state.meta.isValid}
+            />
+          )}
+        />
+
+        <form.Field
+          name="url"
+          children={(field) => (
+            <Input
+              name={field.name}
+              label="URL"
+              value={field.state.value || ''}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+              validationBehavior="aria"
+              errorMessage={field.state.meta.errors
+                .filter((e) => e !== undefined)
+                .map((e) => e.message)
+                .join(', ')}
+              isInvalid={!field.state.meta.isValid}
+            />
+          )}
+        />
+
+        <Button type="submit" isLoading={isPending}>
+          Create Integration
+        </Button>
+
+        <form.Subscribe
+          selector={(state) => state.errors.filter((e) => typeof e === 'string')}
+          children={(errors) => errors.length > 0 && <Alert color="danger">{errors}</Alert>}
+        />
+      </Form>
+    );
+  }
+
+  function RouteComponent() {
+    const user = useStore((store) => store.user);
+
+    if (!user) {
+      return (
+        <div>
+          Please{' '}
+          <Link
+            className="hover:text-primary underline transition-colors"
+            to="/auth/login"
+            search={{ next: '/integrations/create' }}
+          >
+            log in
+          </Link>{' '}
+          to create an integration.
+        </div>
+      );
+    }
+
+    return <CreateIntegrationForm />;
+  }
+  ```
+
+- [ ] **Verify the build passes:**
+
+  ```bash
+  npm run build
+  ```
+
+- [ ] **Manually verify** that creating an integration redirects to `/integrations/` and the new integration appears in the list.
+
+- [ ] **Commit:**
+
+  ```bash
+  git add frontend/src/routes/integrations/create.tsx
+  git commit -m "feat: redirect to integrations list after creation"
+  ```
+
+---
+
+### Final verification
+
+- [ ] **Run a full build to confirm no type errors remain:**
+
+  ```bash
+  npm run build
+  ```
+
+- [ ] **Run the linter:**
+
+  ```bash
+  uv run ruff check hyperioncs/
+  ```
+
+  Expected: no errors.

--- a/docs/superpowers/specs/2026-03-15-integration-management-design.md
+++ b/docs/superpowers/specs/2026-03-15-integration-management-design.md
@@ -12,60 +12,138 @@ Add comprehensive integration management to the HyperionCS app: a list page for 
 ### `IntegrationToken`
 Add a `name: Mapped[str]` column. Requires a new Alembic migration.
 
+**Migration strategy:** The `integration_tokens` table may have existing rows. To add a non-nullable `name` column safely, the Alembic migration should add the column with `server_default=sa.text("''")` (empty string), then remove the server default in the same migration after backfilling. In practice, since this is still in active development with no production data, an empty-string server default is acceptable and can be left in place for simplicity.
+
 No other model changes are needed.
+
+## Frontend Client Regeneration
+
+After all backend changes are complete, the frontend query client must be regenerated before writing frontend code:
+
+```
+npm run gen-openapi
+```
+
+This will update all generated files under `frontend/src/queries/` — including adding `queryParams` support to `listIntegrationsQuery`, generating new queries for the token endpoints and `getIntegrationQuery`, and updating all Zod schemas.
+
+**Query key note:** After regeneration, `listIntegrationsQuery({})` and `listIntegrationsQuery({ queryParams: { manageable: true } })` produce **different cache keys**. The existing currencies manage page calls `listIntegrationsQuery({})` (no filter) — this is intentional and should not be changed. Only the `{ queryParams: { manageable: true } }` variant is used on the new integrations pages and should be invalidated on create.
+
+**`queryParams` is optional** in the regenerated type (FastAPI query params with defaults generate optional fields in OpenAPI). The existing `useSuspenseListIntegrations({})` call on the currencies manage page will remain valid after regeneration without modification.
+
+**Generated hook names** are derived from the Python function names used in the backend router. The following names must be used for the new endpoints so that the generated client has predictable names:
+
+| Python function | Generated query/hook |
+|---|---|
+| `get_integration` | `getIntegrationQuery`, `useSuspenseGetIntegration` |
+| `edit_integration` | `useEditIntegration` |
+| `list_integration_tokens` | `listIntegrationTokensQuery`, `useSuspenseListIntegrationTokens` |
+| `create_integration_token` | `useCreateIntegrationToken` |
+| `delete_integration_token` | `useDeleteIntegrationToken` |
 
 ## Backend API
 
-All new endpoints live in the existing integrations router (`hyperioncs/api/app/routers/integrations.py`). All require the user to have the `Edit` role (`IntegrationRole.Owner`) on the integration.
+All new endpoints live in the existing integrations router (`hyperioncs/api/app/routers/integrations.py`).
+
+**Path parameter naming:** Use `{integration_id}` for all new endpoints, consistent with the existing `/{integration_id}/connect` and `/{integration_id}/disconnect` endpoints.
+
+**Authentication:** All endpoints require the user to be authenticated via `require_session_user`. Unauthenticated requests raise HTTP 401.
+
+**Authorization:** A missing integration, or an integration the user does not have the required role on, returns HTTP 403. Token-level 404s are the exception — see the delete token endpoint.
+
+**Route declaration order:** FastAPI resolves literal paths before parameterized paths within the same method. Declare `GET /` (the existing list endpoint) before `GET /{integration_id}` to ensure the list endpoint is matched first.
 
 ### Extend existing list endpoint
-- `GET /integrations/?manageable=true` — add an optional boolean query param. When `true`, filters to integrations where the current user has an Edit role. When absent or `false`, existing behavior is preserved (public integrations + integrations the user can connect).
+- `GET /integrations/?manageable=true` — add an optional boolean query param. When `true`, filters to integrations where the current user has an Edit role (`IntegrationActionRoles.Edit`). When absent or `false`, existing behavior is preserved (public integrations + integrations the user has a Connect permission for). Authentication is required in both cases, as it is today.
+
+  Note: `IntegrationActionRoles.Edit` and `IntegrationActionRoles.Connect` both equal `[IntegrationRole.Owner]` today. The `manageable` param is semantically distinct — it filters by intent (the user can manage this integration), not by the connect permission. If these role lists diverge in future, the behavior should remain tied to `IntegrationActionRoles.Edit`.
 
 ### New single-integration endpoints
-- `GET /integrations/{id}` — returns a single integration the current user has Edit access to.
-- `PUT /integrations/{id}` — updates `name`, `description`, and `url`. Requires Edit role.
+- `GET /integrations/{integration_id}` — returns a single integration the current user has Edit access to. Response model: `IntegrationSchema` (`id`, `name`, `description`, `url`, `private`). HTTP 200 on success, 403 if not found or no Edit role.
+- `PATCH /integrations/{integration_id}` — updates `name`, `description`, and `url`. All three fields are required; omitting a field is an error, not a partial update. `url` has no default and **must not be given a default value in `EditIntegrationSchema`**, even though `CreateIntegrationSchema.url` uses `default=None`. Sending `url: null` or `url: ""` both clear the URL (via `NullableString`). `private` is not editable via this endpoint. Response model: `IntegrationSchema`. HTTP 200 on success, 403 if not found or no Edit role. Consistent with the existing `PATCH /currencies/{shortcode}` pattern.
 
 ### Token endpoints
-- `GET /integrations/{id}/tokens` — lists tokens for an integration. Response includes `id` and `name` only; the token value is never returned here.
-- `POST /integrations/{id}/tokens` — creates a token with a `name`. Returns `id`, `name`, and `token` (the raw token value). This is the only time the token value is ever returned.
-- `DELETE /integrations/{id}/tokens/{token_id}` — deletes a token. Requires Edit role on the integration.
+- `GET /integrations/{integration_id}/tokens` — lists tokens for an integration. Response model: `list[IntegrationTokenSchema]`. The token value is never returned here. Returns 403 if the integration does not exist or the user lacks Edit role.
+- `POST /integrations/{integration_id}/tokens` — creates a token. Request body: `CreateIntegrationTokenSchema`. Response model: `CreatedIntegrationTokenSchema`. HTTP 201 on success. Returns 403 if the integration does not exist or the user lacks Edit role. This is the only time the token value is ever returned. The token's `id` must be pre-generated explicitly using `id=default_uuid_str()` (consistent with the `create_integration` pattern) so that the `id` is available to build the JWT before the object is flushed to the database.
+- `DELETE /integrations/{integration_id}/tokens/{token_id}` — deletes a token (`token_id: str`). The resource path `/integrations/{integration_id}/tokens/{token_id}` is treated as the full resource identifier — a token only exists at this path if it both exists and belongs to the specified integration. Authorization check order:
+  1. Does the integration exist? → 403 if not.
+  2. Does the user have Edit role on the integration? → 403 if not.
+  3. Does a token with `token_id` exist where `integration_id` matches? → 404 if not.
 
-### Response schemas
-- `IntegrationTokenSchema`: `id`, `name` — used for list responses.
-- `CreatedIntegrationTokenSchema`: `id`, `name`, `token` — used only for the create response.
+  Returns HTTP 202 with an empty body on success.
+
+### Request and response schemas
+
+**`CreateIntegrationTokenSchema`** (request body for token creation):
+- `name: str` — required.
+
+**`EditIntegrationSchema`** (request body for `PATCH /integrations/{integration_id}`):
+- `name: str` — required. No min-length validator; matches the validation level of `CreateIntegrationSchema`.
+- `description: str` — required. No min-length validator; matches the validation level of `CreateIntegrationSchema`.
+- `url: NullableString` — use the existing `NullableString` type (converts empty strings to `None`). **No default** (unlike `CreateIntegrationSchema.url` which has `default=None`); this field is required.
+
+**`IntegrationTokenSchema`** (used for list responses):
+- `id: str`
+- `name: str`
+
+**`CreatedIntegrationTokenSchema`** (used only for the create response, HTTP 201):
+- `id: str`
+- `name: str`
+- `token: str` — a JWT signed with `config.jwt_secret` using `config.jwt_algorithm`, containing a `token_id` claim set to the token's `id`. Consistent with the existing `require_integration` dependency.
 
 ## Frontend
 
+> **Before writing any frontend code**, regenerate the client with `npm run gen-openapi` as described in the Frontend Client Regeneration section above.
+
+### Navbar
+Add an "Integrations" link in `__root.tsx` pointing to `/integrations/`, placed before the existing "Currencies" link.
+
 ### `/integrations/` (new)
 List page for integrations the user can manage. Matches the structure of the currencies list page:
-- Header row with "Integrations" title and a "Create Integration" button (visible only when logged in).
-- List of integrations, each showing name and description, linking to `/integrations/$id/manage`.
-- Data fetched via `listIntegrationsQuery` with `manageable: true`.
+- Header row with "Integrations" title and a "Create Integration" button (visible only when logged in, linking to `/integrations/create`).
+- List of integrations, each showing name and description, linking to `/integrations/$integrationId/manage`.
+- Route defines a `loader` that calls `queryClient.ensureQueryData(listIntegrationsQuery({ queryParams: { manageable: true } }))`, consistent with the pattern used in other list pages.
 
-### `/integrations/$id/manage` (new)
-Management page with two sections, following the pattern of `/currencies/$shortcode/manage`:
+### `/integrations/$integrationId/manage` (new)
+Management page with two sections, following the pattern of `/currencies/$shortcode/manage`. Unauthenticated users navigating directly to this page will have API calls fail with 401, consistent with how the rest of the app handles unauthenticated access to protected pages.
+
+Route defines a `loader` that calls `queryClient.ensureQueryData` for both:
+- `getIntegrationQuery({ pathParams: { integrationId } })`
+- `listIntegrationTokensQuery({ pathParams: { integrationId } })`
 
 **Edit Integration Details**
-- Form pre-populated with `name`, `description`, and `url`.
-- On save, calls `PUT /integrations/{id}` and invalidates the integration query.
-- `private` is not editable here (reserved for future admin functionality).
+- Form pre-populated with `name`, `description`, and `url` from `getIntegrationQuery`. Since `url` may be `null`, render it as an empty string in the input (consistent with the `value={field.state.value || ''}` pattern already used in `create.tsx`).
+- On save, calls `PATCH /integrations/{integration_id}` then `await queryClient.invalidateQueries(getIntegrationQuery({ pathParams: { integrationId } }))`.
+- On success: show a success alert driven by the mutation `data` value (consistent with `ManageCurrencyDetails`).
+- On error: call `form.setErrorMap(...)` to display the error detail, with an `Alert color="danger"` via `form.Subscribe` (consistent with the `ManageCurrencyDetails` error handling pattern).
+- `private` is not shown or editable (reserved for future admin functionality).
 
 **Manage Tokens**
-- List of existing tokens showing name only, each with a "Delete" button.
-- "Create Token" button reveals an inline form with a `name` field and a submit button.
-- On successful creation, a modal appears containing:
-  - The token value in a copyable display.
-  - A warning that the value will not be shown again.
-  - A dismiss button.
+- List of existing tokens from `listIntegrationTokensQuery`, showing name only, each with a "Delete" button.
+- "Create Token" button reveals an inline form with a `name` field and a submit button. Clicking "Create Token" again while the form is visible collapses it (toggle behavior). The form resets each time it is opened.
+- On successful creation:
+  1. Capture the `token` value from the mutation response into local component state before clearing any mutation state.
+  2. The inline form collapses and resets.
+  3. `await queryClient.invalidateQueries(listIntegrationTokensQuery({ pathParams: { integrationId } }))` — wait for the list to refresh.
+  4. A modal appears containing the token value (from local state) in a copyable display, a warning that the value will not be shown again, and a dismiss button. Dismissing the modal clears the local state — the token value is not recoverable without creating a new token.
+- On delete:
+  - Call `DELETE /integrations/{integration_id}/tokens/{token_id}`.
+  - On success: `await queryClient.invalidateQueries(listIntegrationTokensQuery({ pathParams: { integrationId } }))`.
+  - On error: show an inline error alert (consistent with the `Alert color="danger"` pattern used elsewhere).
+  - Token operations do not modify the integration itself, so `getIntegrationQuery` does not need to be invalidated.
 
 ### `/integrations/create` (modified)
-After successful creation, redirect to `/integrations/` instead of showing a static success alert, so the user lands on the list with their new integration visible.
+After successful creation:
+1. `await queryClient.invalidateQueries(listIntegrationsQuery({ queryParams: { manageable: true } }))` — invalidate only this variant; `listIntegrationsQuery({})` (used on the currencies manage page) should not be invalidated here.
+2. Use `useNavigate` to redirect to `/integrations/`, consistent with the pattern for post-submit navigation in the rest of the frontend.
+
+Remove the existing `{data && <Alert color="success">Integration created!</Alert>}` line — it is unreachable after the redirect.
 
 ## Error Handling
 
-- 403 if user lacks Edit role on the integration (get, edit, token operations).
-- 404 if integration does not exist.
-- Follows existing error handling patterns (JSONResponse with `ErrorResponseSchema`).
+- HTTP 401 if the user is not authenticated (raised by `require_session_user`).
+- HTTP 403 if the user lacks the required role on the integration, or if the integration does not exist.
+- HTTP 404 for token not found or not belonging to the specified integration on the delete endpoint.
+- Follows existing error handling patterns (`JSONResponse` with `ErrorResponseSchema`).
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-03-15-integration-management-design.md
+++ b/docs/superpowers/specs/2026-03-15-integration-management-design.md
@@ -1,0 +1,74 @@
+# Integration Management Feature Design
+
+**Date:** 2026-03-15
+**Branch:** integration-management
+
+## Overview
+
+Add comprehensive integration management to the HyperionCS app: a list page for integrations the user owns, a management page for editing metadata and managing tokens, and token name support.
+
+## Data Model
+
+### `IntegrationToken`
+Add a `name: Mapped[str]` column. Requires a new Alembic migration.
+
+No other model changes are needed.
+
+## Backend API
+
+All new endpoints live in the existing integrations router (`hyperioncs/api/app/routers/integrations.py`). All require the user to have the `Edit` role (`IntegrationRole.Owner`) on the integration.
+
+### Extend existing list endpoint
+- `GET /integrations/?manageable=true` — add an optional boolean query param. When `true`, filters to integrations where the current user has an Edit role. When absent or `false`, existing behavior is preserved (public integrations + integrations the user can connect).
+
+### New single-integration endpoints
+- `GET /integrations/{id}` — returns a single integration the current user has Edit access to.
+- `PUT /integrations/{id}` — updates `name`, `description`, and `url`. Requires Edit role.
+
+### Token endpoints
+- `GET /integrations/{id}/tokens` — lists tokens for an integration. Response includes `id` and `name` only; the token value is never returned here.
+- `POST /integrations/{id}/tokens` — creates a token with a `name`. Returns `id`, `name`, and `token` (the raw token value). This is the only time the token value is ever returned.
+- `DELETE /integrations/{id}/tokens/{token_id}` — deletes a token. Requires Edit role on the integration.
+
+### Response schemas
+- `IntegrationTokenSchema`: `id`, `name` — used for list responses.
+- `CreatedIntegrationTokenSchema`: `id`, `name`, `token` — used only for the create response.
+
+## Frontend
+
+### `/integrations/` (new)
+List page for integrations the user can manage. Matches the structure of the currencies list page:
+- Header row with "Integrations" title and a "Create Integration" button (visible only when logged in).
+- List of integrations, each showing name and description, linking to `/integrations/$id/manage`.
+- Data fetched via `listIntegrationsQuery` with `manageable: true`.
+
+### `/integrations/$id/manage` (new)
+Management page with two sections, following the pattern of `/currencies/$shortcode/manage`:
+
+**Edit Integration Details**
+- Form pre-populated with `name`, `description`, and `url`.
+- On save, calls `PUT /integrations/{id}` and invalidates the integration query.
+- `private` is not editable here (reserved for future admin functionality).
+
+**Manage Tokens**
+- List of existing tokens showing name only, each with a "Delete" button.
+- "Create Token" button reveals an inline form with a `name` field and a submit button.
+- On successful creation, a modal appears containing:
+  - The token value in a copyable display.
+  - A warning that the value will not be shown again.
+  - A dismiss button.
+
+### `/integrations/create` (modified)
+After successful creation, redirect to `/integrations/` instead of showing a static success alert, so the user lands on the list with their new integration visible.
+
+## Error Handling
+
+- 403 if user lacks Edit role on the integration (get, edit, token operations).
+- 404 if integration does not exist.
+- Follows existing error handling patterns (JSONResponse with `ErrorResponseSchema`).
+
+## Out of Scope
+
+- Editing the `private` flag (future admin feature).
+- Renaming tokens after creation.
+- Viewing token values after initial creation.

--- a/docs/superpowers/specs/2026-03-15-integration-management-design.md
+++ b/docs/superpowers/specs/2026-03-15-integration-management-design.md
@@ -12,7 +12,10 @@ Add comprehensive integration management to the HyperionCS app: a list page for 
 ### `IntegrationToken`
 Add a `name: Mapped[str]` column. Requires a new Alembic migration.
 
-**Migration strategy:** The `integration_tokens` table may have existing rows. To add a non-nullable `name` column safely, the Alembic migration should add the column with `server_default=sa.text("''")` (empty string), then remove the server default in the same migration after backfilling. In practice, since this is still in active development with no production data, an empty-string server default is acceptable and can be left in place for simplicity.
+**Migration strategy:** There is no existing data in `integration_tokens`. Amend the existing `integration_tokens` migration (rather than creating a new one) to include the `name` column from the start.
+
+### `IntegrationRole` / `IntegrationActionRoles`
+Add a new `View = "view"` value to `IntegrationRole` and a corresponding `IntegrationActionRoles.View = [IntegrationRole.View, IntegrationRole.Owner]` action role list. This represents the minimum role required to view a private integration's details.
 
 No other model changes are needed.
 
@@ -58,7 +61,7 @@ All new endpoints live in the existing integrations router (`hyperioncs/api/app/
   Note: `IntegrationActionRoles.Edit` and `IntegrationActionRoles.Connect` both equal `[IntegrationRole.Owner]` today. The `manageable` param is semantically distinct — it filters by intent (the user can manage this integration), not by the connect permission. If these role lists diverge in future, the behavior should remain tied to `IntegrationActionRoles.Edit`.
 
 ### New single-integration endpoints
-- `GET /integrations/{integration_id}` — returns a single integration the current user has Edit access to. Response model: `IntegrationSchema` (`id`, `name`, `description`, `url`, `private`). HTTP 200 on success, 403 if not found or no Edit role.
+- `GET /integrations/{integration_id}` — returns a single integration visible to the current user. Access rules mirror the existing list endpoint: public integrations are accessible to anyone (authenticated); private integrations require the user to have a View role (`IntegrationActionRoles.View`). Response model: `IntegrationSchema` (`id`, `name`, `description`, `url`, `private`). HTTP 200 on success, 403 if not found or access not permitted.
 - `PATCH /integrations/{integration_id}` — updates `name`, `description`, and `url`. All three fields are required; omitting a field is an error, not a partial update. `url` has no default and **must not be given a default value in `EditIntegrationSchema`**, even though `CreateIntegrationSchema.url` uses `default=None`. Sending `url: null` or `url: ""` both clear the URL (via `NullableString`). `private` is not editable via this endpoint. Response model: `IntegrationSchema`. HTTP 200 on success, 403 if not found or no Edit role. Consistent with the existing `PATCH /currencies/{shortcode}` pattern.
 
 ### Token endpoints

--- a/frontend/src/queries/integrations/v1/integrationsV1Schemas.ts
+++ b/frontend/src/queries/integrations/v1/integrationsV1Schemas.ts
@@ -40,4 +40,6 @@ export type ValidationError = {
   loc: (string | number)[];
   msg: string;
   type: string;
+  input?: void;
+  ctx?: Record<string, any>;
 };

--- a/frontend/src/queries/integrations/v1/integrationsV1Schemas.zod.ts
+++ b/frontend/src/queries/integrations/v1/integrationsV1Schemas.zod.ts
@@ -16,6 +16,8 @@ export const ValidationErrorZod = z.object({
   loc: z.array(z.union([z.string(), z.number()])),
   msg: z.string(),
   type: z.string(),
+  input: z.void().optional(),
+  ctx: z.record(z.string(), z.any()).optional(),
 });
 
 export const HTTPValidationErrorZod = z.object({

--- a/frontend/src/queries/internal/internalComponents.ts
+++ b/frontend/src/queries/internal/internalComponents.ts
@@ -384,86 +384,6 @@ export const useGetCurrencyIntegrations = <TData = GetCurrencyIntegrationsRespon
   });
 };
 
-export type ListIntegrationsError = Fetcher.ErrorWrapper<undefined>;
-
-export type ListIntegrationsResponse = Schemas.IntegrationSchema[];
-
-export type ListIntegrationsVariables = InternalContext['fetcherOptions'];
-
-/**
- * List all integrations the current user has access to.
- */
-export const fetchListIntegrations = (variables: ListIntegrationsVariables, signal?: AbortSignal) =>
-  internalFetch<ListIntegrationsResponse, ListIntegrationsError, undefined, {}, {}, {}>({
-    url: '/api/internal/integrations/',
-    method: 'get',
-    ...variables,
-    signal,
-  });
-
-/**
- * List all integrations the current user has access to.
- */
-export function listIntegrationsQuery(variables: ListIntegrationsVariables): {
-  queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<ListIntegrationsResponse>;
-};
-
-export function listIntegrationsQuery(variables: ListIntegrationsVariables | reactQuery.SkipToken): {
-  queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<ListIntegrationsResponse>) | reactQuery.SkipToken;
-};
-
-export function listIntegrationsQuery(variables: ListIntegrationsVariables | reactQuery.SkipToken) {
-  return {
-    queryKey: queryKeyFn({
-      path: '/api/internal/integrations/',
-      operationId: 'listIntegrations',
-      variables,
-    }),
-    queryFn:
-      variables === reactQuery.skipToken
-        ? reactQuery.skipToken
-        : ({ signal }: QueryFnOptions) => fetchListIntegrations(variables, signal),
-  };
-}
-
-/**
- * List all integrations the current user has access to.
- */
-export const useSuspenseListIntegrations = <TData = ListIntegrationsResponse>(
-  variables: ListIntegrationsVariables,
-  options?: Omit<
-    reactQuery.UseQueryOptions<ListIntegrationsResponse, ListIntegrationsError, TData>,
-    'queryKey' | 'queryFn' | 'initialData'
-  >,
-) => {
-  const { queryOptions, fetcherOptions } = useInternalContext(options);
-  return reactQuery.useSuspenseQuery<ListIntegrationsResponse, ListIntegrationsError, TData>({
-    ...listIntegrationsQuery(deepMerge(fetcherOptions, variables)),
-    ...options,
-    ...queryOptions,
-  });
-};
-
-/**
- * List all integrations the current user has access to.
- */
-export const useListIntegrations = <TData = ListIntegrationsResponse>(
-  variables: ListIntegrationsVariables | reactQuery.SkipToken,
-  options?: Omit<
-    reactQuery.UseQueryOptions<ListIntegrationsResponse, ListIntegrationsError, TData>,
-    'queryKey' | 'queryFn' | 'initialData'
-  >,
-) => {
-  const { queryOptions, fetcherOptions } = useInternalContext(options);
-  return reactQuery.useQuery<ListIntegrationsResponse, ListIntegrationsError, TData>({
-    ...listIntegrationsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
-    ...options,
-    ...queryOptions,
-  });
-};
-
 export type CreateIntegrationError = Fetcher.ErrorWrapper<{
   status: 422;
   payload: Schemas.HTTPValidationError;
@@ -496,6 +416,492 @@ export const useCreateIntegration = (
   const { fetcherOptions } = useInternalContext();
   return reactQuery.useMutation<Schemas.IntegrationSchema, CreateIntegrationError, CreateIntegrationVariables>({
     mutationFn: (variables: CreateIntegrationVariables) => fetchCreateIntegration(deepMerge(fetcherOptions, variables)),
+    ...options,
+  });
+};
+
+export type ListIntegrationsQueryParams = {
+  /**
+   * @default false
+   */
+  manageable?: boolean;
+};
+
+export type ListIntegrationsError = Fetcher.ErrorWrapper<{
+  status: 422;
+  payload: Schemas.HTTPValidationError;
+}>;
+
+export type ListIntegrationsResponse = Schemas.IntegrationSchema[];
+
+export type ListIntegrationsVariables = {
+  queryParams?: ListIntegrationsQueryParams;
+} & InternalContext['fetcherOptions'];
+
+/**
+ * List integrations visible to the current user.
+ *
+ * When manageable=true, returns only integrations the user can edit.
+ * Otherwise returns public integrations and integrations the user can connect.
+ */
+export const fetchListIntegrations = (variables: ListIntegrationsVariables, signal?: AbortSignal) =>
+  internalFetch<ListIntegrationsResponse, ListIntegrationsError, undefined, {}, ListIntegrationsQueryParams, {}>({
+    url: '/api/internal/integrations/',
+    method: 'get',
+    ...variables,
+    signal,
+  });
+
+/**
+ * List integrations visible to the current user.
+ *
+ * When manageable=true, returns only integrations the user can edit.
+ * Otherwise returns public integrations and integrations the user can connect.
+ */
+export function listIntegrationsQuery(variables: ListIntegrationsVariables): {
+  queryKey: reactQuery.QueryKey;
+  queryFn: (options: QueryFnOptions) => Promise<ListIntegrationsResponse>;
+};
+
+export function listIntegrationsQuery(variables: ListIntegrationsVariables | reactQuery.SkipToken): {
+  queryKey: reactQuery.QueryKey;
+  queryFn: ((options: QueryFnOptions) => Promise<ListIntegrationsResponse>) | reactQuery.SkipToken;
+};
+
+export function listIntegrationsQuery(variables: ListIntegrationsVariables | reactQuery.SkipToken) {
+  return {
+    queryKey: queryKeyFn({
+      path: '/api/internal/integrations/',
+      operationId: 'listIntegrations',
+      variables,
+    }),
+    queryFn:
+      variables === reactQuery.skipToken
+        ? reactQuery.skipToken
+        : ({ signal }: QueryFnOptions) => fetchListIntegrations(variables, signal),
+  };
+}
+
+/**
+ * List integrations visible to the current user.
+ *
+ * When manageable=true, returns only integrations the user can edit.
+ * Otherwise returns public integrations and integrations the user can connect.
+ */
+export const useSuspenseListIntegrations = <TData = ListIntegrationsResponse>(
+  variables: ListIntegrationsVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<ListIntegrationsResponse, ListIntegrationsError, TData>,
+    'queryKey' | 'queryFn' | 'initialData'
+  >,
+) => {
+  const { queryOptions, fetcherOptions } = useInternalContext(options);
+  return reactQuery.useSuspenseQuery<ListIntegrationsResponse, ListIntegrationsError, TData>({
+    ...listIntegrationsQuery(deepMerge(fetcherOptions, variables)),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+/**
+ * List integrations visible to the current user.
+ *
+ * When manageable=true, returns only integrations the user can edit.
+ * Otherwise returns public integrations and integrations the user can connect.
+ */
+export const useListIntegrations = <TData = ListIntegrationsResponse>(
+  variables: ListIntegrationsVariables | reactQuery.SkipToken,
+  options?: Omit<
+    reactQuery.UseQueryOptions<ListIntegrationsResponse, ListIntegrationsError, TData>,
+    'queryKey' | 'queryFn' | 'initialData'
+  >,
+) => {
+  const { queryOptions, fetcherOptions } = useInternalContext(options);
+  return reactQuery.useQuery<ListIntegrationsResponse, ListIntegrationsError, TData>({
+    ...listIntegrationsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+export type GetIntegrationPathParams = {
+  integrationId: string;
+};
+
+export type GetIntegrationError = Fetcher.ErrorWrapper<
+  | {
+      status: 403;
+      payload: Schemas.ErrorResponseSchema;
+    }
+  | {
+      status: 422;
+      payload: Schemas.HTTPValidationError;
+    }
+>;
+
+export type GetIntegrationVariables = {
+  pathParams: GetIntegrationPathParams;
+} & InternalContext['fetcherOptions'];
+
+/**
+ * Get a single integration visible to the current user.
+ *
+ * Public integrations are accessible to all authenticated users.
+ * Private integrations require the View role.
+ */
+export const fetchGetIntegration = (variables: GetIntegrationVariables, signal?: AbortSignal) =>
+  internalFetch<Schemas.IntegrationSchema, GetIntegrationError, undefined, {}, {}, GetIntegrationPathParams>({
+    url: '/api/internal/integrations/{integrationId}',
+    method: 'get',
+    ...variables,
+    signal,
+  });
+
+/**
+ * Get a single integration visible to the current user.
+ *
+ * Public integrations are accessible to all authenticated users.
+ * Private integrations require the View role.
+ */
+export function getIntegrationQuery(variables: GetIntegrationVariables): {
+  queryKey: reactQuery.QueryKey;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.IntegrationSchema>;
+};
+
+export function getIntegrationQuery(variables: GetIntegrationVariables | reactQuery.SkipToken): {
+  queryKey: reactQuery.QueryKey;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.IntegrationSchema>) | reactQuery.SkipToken;
+};
+
+export function getIntegrationQuery(variables: GetIntegrationVariables | reactQuery.SkipToken) {
+  return {
+    queryKey: queryKeyFn({
+      path: '/api/internal/integrations/{integrationId}',
+      operationId: 'getIntegration',
+      variables,
+    }),
+    queryFn:
+      variables === reactQuery.skipToken
+        ? reactQuery.skipToken
+        : ({ signal }: QueryFnOptions) => fetchGetIntegration(variables, signal),
+  };
+}
+
+/**
+ * Get a single integration visible to the current user.
+ *
+ * Public integrations are accessible to all authenticated users.
+ * Private integrations require the View role.
+ */
+export const useSuspenseGetIntegration = <TData = Schemas.IntegrationSchema>(
+  variables: GetIntegrationVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<Schemas.IntegrationSchema, GetIntegrationError, TData>,
+    'queryKey' | 'queryFn' | 'initialData'
+  >,
+) => {
+  const { queryOptions, fetcherOptions } = useInternalContext(options);
+  return reactQuery.useSuspenseQuery<Schemas.IntegrationSchema, GetIntegrationError, TData>({
+    ...getIntegrationQuery(deepMerge(fetcherOptions, variables)),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+/**
+ * Get a single integration visible to the current user.
+ *
+ * Public integrations are accessible to all authenticated users.
+ * Private integrations require the View role.
+ */
+export const useGetIntegration = <TData = Schemas.IntegrationSchema>(
+  variables: GetIntegrationVariables | reactQuery.SkipToken,
+  options?: Omit<
+    reactQuery.UseQueryOptions<Schemas.IntegrationSchema, GetIntegrationError, TData>,
+    'queryKey' | 'queryFn' | 'initialData'
+  >,
+) => {
+  const { queryOptions, fetcherOptions } = useInternalContext(options);
+  return reactQuery.useQuery<Schemas.IntegrationSchema, GetIntegrationError, TData>({
+    ...getIntegrationQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+export type EditIntegrationPathParams = {
+  integrationId: string;
+};
+
+export type EditIntegrationError = Fetcher.ErrorWrapper<
+  | {
+      status: 403;
+      payload: Schemas.ErrorResponseSchema;
+    }
+  | {
+      status: 422;
+      payload: Schemas.HTTPValidationError;
+    }
+>;
+
+export type EditIntegrationVariables = {
+  body: Schemas.EditIntegrationSchema;
+  pathParams: EditIntegrationPathParams;
+} & InternalContext['fetcherOptions'];
+
+/**
+ * Edit an integration's metadata. Requires Edit role.
+ */
+export const fetchEditIntegration = (variables: EditIntegrationVariables, signal?: AbortSignal) =>
+  internalFetch<
+    Schemas.IntegrationSchema,
+    EditIntegrationError,
+    Schemas.EditIntegrationSchema,
+    {},
+    {},
+    EditIntegrationPathParams
+  >({
+    url: '/api/internal/integrations/{integrationId}',
+    method: 'patch',
+    ...variables,
+    signal,
+  });
+
+/**
+ * Edit an integration's metadata. Requires Edit role.
+ */
+export const useEditIntegration = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<Schemas.IntegrationSchema, EditIntegrationError, EditIntegrationVariables>,
+    'mutationFn'
+  >,
+) => {
+  const { fetcherOptions } = useInternalContext();
+  return reactQuery.useMutation<Schemas.IntegrationSchema, EditIntegrationError, EditIntegrationVariables>({
+    mutationFn: (variables: EditIntegrationVariables) => fetchEditIntegration(deepMerge(fetcherOptions, variables)),
+    ...options,
+  });
+};
+
+export type ListIntegrationTokensPathParams = {
+  integrationId: string;
+};
+
+export type ListIntegrationTokensError = Fetcher.ErrorWrapper<
+  | {
+      status: 403;
+      payload: Schemas.ErrorResponseSchema;
+    }
+  | {
+      status: 422;
+      payload: Schemas.HTTPValidationError;
+    }
+>;
+
+export type ListIntegrationTokensResponse = Schemas.IntegrationTokenSchema[];
+
+export type ListIntegrationTokensVariables = {
+  pathParams: ListIntegrationTokensPathParams;
+} & InternalContext['fetcherOptions'];
+
+/**
+ * List tokens for an integration. Requires Edit role.
+ */
+export const fetchListIntegrationTokens = (variables: ListIntegrationTokensVariables, signal?: AbortSignal) =>
+  internalFetch<
+    ListIntegrationTokensResponse,
+    ListIntegrationTokensError,
+    undefined,
+    {},
+    {},
+    ListIntegrationTokensPathParams
+  >({
+    url: '/api/internal/integrations/{integrationId}/tokens',
+    method: 'get',
+    ...variables,
+    signal,
+  });
+
+/**
+ * List tokens for an integration. Requires Edit role.
+ */
+export function listIntegrationTokensQuery(variables: ListIntegrationTokensVariables): {
+  queryKey: reactQuery.QueryKey;
+  queryFn: (options: QueryFnOptions) => Promise<ListIntegrationTokensResponse>;
+};
+
+export function listIntegrationTokensQuery(variables: ListIntegrationTokensVariables | reactQuery.SkipToken): {
+  queryKey: reactQuery.QueryKey;
+  queryFn: ((options: QueryFnOptions) => Promise<ListIntegrationTokensResponse>) | reactQuery.SkipToken;
+};
+
+export function listIntegrationTokensQuery(variables: ListIntegrationTokensVariables | reactQuery.SkipToken) {
+  return {
+    queryKey: queryKeyFn({
+      path: '/api/internal/integrations/{integrationId}/tokens',
+      operationId: 'listIntegrationTokens',
+      variables,
+    }),
+    queryFn:
+      variables === reactQuery.skipToken
+        ? reactQuery.skipToken
+        : ({ signal }: QueryFnOptions) => fetchListIntegrationTokens(variables, signal),
+  };
+}
+
+/**
+ * List tokens for an integration. Requires Edit role.
+ */
+export const useSuspenseListIntegrationTokens = <TData = ListIntegrationTokensResponse>(
+  variables: ListIntegrationTokensVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<ListIntegrationTokensResponse, ListIntegrationTokensError, TData>,
+    'queryKey' | 'queryFn' | 'initialData'
+  >,
+) => {
+  const { queryOptions, fetcherOptions } = useInternalContext(options);
+  return reactQuery.useSuspenseQuery<ListIntegrationTokensResponse, ListIntegrationTokensError, TData>({
+    ...listIntegrationTokensQuery(deepMerge(fetcherOptions, variables)),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+/**
+ * List tokens for an integration. Requires Edit role.
+ */
+export const useListIntegrationTokens = <TData = ListIntegrationTokensResponse>(
+  variables: ListIntegrationTokensVariables | reactQuery.SkipToken,
+  options?: Omit<
+    reactQuery.UseQueryOptions<ListIntegrationTokensResponse, ListIntegrationTokensError, TData>,
+    'queryKey' | 'queryFn' | 'initialData'
+  >,
+) => {
+  const { queryOptions, fetcherOptions } = useInternalContext(options);
+  return reactQuery.useQuery<ListIntegrationTokensResponse, ListIntegrationTokensError, TData>({
+    ...listIntegrationTokensQuery(
+      variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables),
+    ),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+export type CreateIntegrationTokenPathParams = {
+  integrationId: string;
+};
+
+export type CreateIntegrationTokenError = Fetcher.ErrorWrapper<
+  | {
+      status: 403;
+      payload: Schemas.ErrorResponseSchema;
+    }
+  | {
+      status: 422;
+      payload: Schemas.HTTPValidationError;
+    }
+>;
+
+export type CreateIntegrationTokenVariables = {
+  body: Schemas.CreateIntegrationTokenSchema;
+  pathParams: CreateIntegrationTokenPathParams;
+} & InternalContext['fetcherOptions'];
+
+/**
+ * Create a new token for an integration. Requires Edit role.
+ *
+ * The token value is only returned in this response — it cannot be retrieved later.
+ */
+export const fetchCreateIntegrationToken = (variables: CreateIntegrationTokenVariables, signal?: AbortSignal) =>
+  internalFetch<
+    Schemas.CreatedIntegrationTokenSchema,
+    CreateIntegrationTokenError,
+    Schemas.CreateIntegrationTokenSchema,
+    {},
+    {},
+    CreateIntegrationTokenPathParams
+  >({
+    url: '/api/internal/integrations/{integrationId}/tokens',
+    method: 'post',
+    ...variables,
+    signal,
+  });
+
+/**
+ * Create a new token for an integration. Requires Edit role.
+ *
+ * The token value is only returned in this response — it cannot be retrieved later.
+ */
+export const useCreateIntegrationToken = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      Schemas.CreatedIntegrationTokenSchema,
+      CreateIntegrationTokenError,
+      CreateIntegrationTokenVariables
+    >,
+    'mutationFn'
+  >,
+) => {
+  const { fetcherOptions } = useInternalContext();
+  return reactQuery.useMutation<
+    Schemas.CreatedIntegrationTokenSchema,
+    CreateIntegrationTokenError,
+    CreateIntegrationTokenVariables
+  >({
+    mutationFn: (variables: CreateIntegrationTokenVariables) =>
+      fetchCreateIntegrationToken(deepMerge(fetcherOptions, variables)),
+    ...options,
+  });
+};
+
+export type DeleteIntegrationTokenPathParams = {
+  integrationId: string;
+  tokenId: string;
+};
+
+export type DeleteIntegrationTokenError = Fetcher.ErrorWrapper<
+  | {
+      status: 403;
+      payload: Schemas.ErrorResponseSchema;
+    }
+  | {
+      status: 404;
+      payload: Schemas.ErrorResponseSchema;
+    }
+  | {
+      status: 422;
+      payload: Schemas.HTTPValidationError;
+    }
+>;
+
+export type DeleteIntegrationTokenVariables = {
+  pathParams: DeleteIntegrationTokenPathParams;
+} & InternalContext['fetcherOptions'];
+
+/**
+ * Delete an integration token. Requires Edit role.
+ */
+export const fetchDeleteIntegrationToken = (variables: DeleteIntegrationTokenVariables, signal?: AbortSignal) =>
+  internalFetch<void, DeleteIntegrationTokenError, undefined, {}, {}, DeleteIntegrationTokenPathParams>({
+    url: '/api/internal/integrations/{integrationId}/tokens/{tokenId}',
+    method: 'delete',
+    ...variables,
+    signal,
+  });
+
+/**
+ * Delete an integration token. Requires Edit role.
+ */
+export const useDeleteIntegrationToken = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<void, DeleteIntegrationTokenError, DeleteIntegrationTokenVariables>,
+    'mutationFn'
+  >,
+) => {
+  const { fetcherOptions } = useInternalContext();
+  return reactQuery.useMutation<void, DeleteIntegrationTokenError, DeleteIntegrationTokenVariables>({
+    mutationFn: (variables: DeleteIntegrationTokenVariables) =>
+      fetchDeleteIntegrationToken(deepMerge(fetcherOptions, variables)),
     ...options,
   });
 };
@@ -631,4 +1037,14 @@ export type QueryOperation =
       path: '/api/internal/integrations/';
       operationId: 'listIntegrations';
       variables: ListIntegrationsVariables | reactQuery.SkipToken;
+    }
+  | {
+      path: '/api/internal/integrations/{integrationId}';
+      operationId: 'getIntegration';
+      variables: GetIntegrationVariables | reactQuery.SkipToken;
+    }
+  | {
+      path: '/api/internal/integrations/{integrationId}/tokens';
+      operationId: 'listIntegrationTokens';
+      variables: ListIntegrationTokensVariables | reactQuery.SkipToken;
     };

--- a/frontend/src/queries/internal/internalSchemas.ts
+++ b/frontend/src/queries/internal/internalSchemas.ts
@@ -46,6 +46,28 @@ export type CreateIntegrationSchema = {
   url?: string | null;
 };
 
+export type CreateIntegrationTokenSchema = {
+  /**
+   * The name of the token.
+   */
+  name: string;
+};
+
+export type CreatedIntegrationTokenSchema = {
+  /**
+   * The unique identifier of the token.
+   */
+  id: string;
+  /**
+   * The name of the token.
+   */
+  name: string;
+  /**
+   * The JWT token value. Only returned at creation time.
+   */
+  token: string;
+};
+
 export type CurrencyPermissionsSchema = {
   /**
    * Whether the user can edit the currency.
@@ -89,6 +111,21 @@ export type EditCurrencySchema = {
   plural_form: string;
 };
 
+export type EditIntegrationSchema = {
+  /**
+   * The name of the integration.
+   */
+  name: string;
+  /**
+   * A description of the integration.
+   */
+  description: string;
+  /**
+   * URL to the website for the integration.
+   */
+  url: string | null;
+};
+
 /**
  * A generic error response.
  */
@@ -126,6 +163,17 @@ export type IntegrationSchema = {
   private: boolean;
 };
 
+export type IntegrationTokenSchema = {
+  /**
+   * The unique identifier of the token.
+   */
+  id: string;
+  /**
+   * The name of the token.
+   */
+  name: string;
+};
+
 /**
  * Details of the currently authenticated user.
  */
@@ -140,4 +188,6 @@ export type ValidationError = {
   loc: (string | number)[];
   msg: string;
   type: string;
+  input?: void;
+  ctx?: Record<string, any>;
 };

--- a/frontend/src/queries/internal/internalSchemas.zod.ts
+++ b/frontend/src/queries/internal/internalSchemas.zod.ts
@@ -18,6 +18,16 @@ export const CreateIntegrationSchemaZod = z.object({
   url: z.string().optional().nullable(),
 });
 
+export const CreateIntegrationTokenSchemaZod = z.object({
+  name: z.string(),
+});
+
+export const CreatedIntegrationTokenSchemaZod = z.object({
+  id: z.string(),
+  name: z.string(),
+  token: z.string(),
+});
+
 export const CurrencyPermissionsSchemaZod = z.object({
   edit: z.boolean().optional().default(false),
 });
@@ -35,6 +45,12 @@ export const EditCurrencySchemaZod = z.object({
   plural_form: z.string(),
 });
 
+export const EditIntegrationSchemaZod = z.object({
+  name: z.string(),
+  description: z.string(),
+  url: z.string().nullable(),
+});
+
 export const ErrorResponseSchemaZod = z.object({
   detail: z.string(),
 });
@@ -43,6 +59,8 @@ export const ValidationErrorZod = z.object({
   loc: z.array(z.union([z.string(), z.number()])),
   msg: z.string(),
   type: z.string(),
+  input: z.void().optional(),
+  ctx: z.record(z.string(), z.any()).optional(),
 });
 
 export const IntegrationSchemaZod = z.object({
@@ -51,6 +69,11 @@ export const IntegrationSchemaZod = z.object({
   description: z.string(),
   url: z.string().optional().nullable(),
   private: z.boolean(),
+});
+
+export const IntegrationTokenSchemaZod = z.object({
+  id: z.string(),
+  name: z.string(),
 });
 
 export const SessionUserZod = z.object({

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -10,17 +10,24 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as IntegrationsIndexRouteImport } from './routes/integrations/index'
 import { Route as CurrenciesIndexRouteImport } from './routes/currencies/index'
 import { Route as IntegrationsCreateRouteImport } from './routes/integrations/create'
 import { Route as CurrenciesCreateRouteImport } from './routes/currencies/create'
 import { Route as AuthLogoutRouteImport } from './routes/auth/logout'
 import { Route as AuthLoginRouteImport } from './routes/auth/login'
 import { Route as CurrenciesShortcodeIndexRouteImport } from './routes/currencies/$shortcode/index'
+import { Route as IntegrationsIntegrationIdManageRouteImport } from './routes/integrations/$integrationId/manage'
 import { Route as CurrenciesShortcodeManageRouteImport } from './routes/currencies/$shortcode/manage'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const IntegrationsIndexRoute = IntegrationsIndexRouteImport.update({
+  id: '/integrations/',
+  path: '/integrations/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CurrenciesIndexRoute = CurrenciesIndexRouteImport.update({
@@ -54,6 +61,12 @@ const CurrenciesShortcodeIndexRoute =
     path: '/currencies/$shortcode/',
     getParentRoute: () => rootRouteImport,
   } as any)
+const IntegrationsIntegrationIdManageRoute =
+  IntegrationsIntegrationIdManageRouteImport.update({
+    id: '/integrations/$integrationId/manage',
+    path: '/integrations/$integrationId/manage',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const CurrenciesShortcodeManageRoute =
   CurrenciesShortcodeManageRouteImport.update({
     id: '/currencies/$shortcode/manage',
@@ -68,7 +81,9 @@ export interface FileRoutesByFullPath {
   '/currencies/create': typeof CurrenciesCreateRoute
   '/integrations/create': typeof IntegrationsCreateRoute
   '/currencies/': typeof CurrenciesIndexRoute
+  '/integrations/': typeof IntegrationsIndexRoute
   '/currencies/$shortcode/manage': typeof CurrenciesShortcodeManageRoute
+  '/integrations/$integrationId/manage': typeof IntegrationsIntegrationIdManageRoute
   '/currencies/$shortcode/': typeof CurrenciesShortcodeIndexRoute
 }
 export interface FileRoutesByTo {
@@ -78,7 +93,9 @@ export interface FileRoutesByTo {
   '/currencies/create': typeof CurrenciesCreateRoute
   '/integrations/create': typeof IntegrationsCreateRoute
   '/currencies': typeof CurrenciesIndexRoute
+  '/integrations': typeof IntegrationsIndexRoute
   '/currencies/$shortcode/manage': typeof CurrenciesShortcodeManageRoute
+  '/integrations/$integrationId/manage': typeof IntegrationsIntegrationIdManageRoute
   '/currencies/$shortcode': typeof CurrenciesShortcodeIndexRoute
 }
 export interface FileRoutesById {
@@ -89,7 +106,9 @@ export interface FileRoutesById {
   '/currencies/create': typeof CurrenciesCreateRoute
   '/integrations/create': typeof IntegrationsCreateRoute
   '/currencies/': typeof CurrenciesIndexRoute
+  '/integrations/': typeof IntegrationsIndexRoute
   '/currencies/$shortcode/manage': typeof CurrenciesShortcodeManageRoute
+  '/integrations/$integrationId/manage': typeof IntegrationsIntegrationIdManageRoute
   '/currencies/$shortcode/': typeof CurrenciesShortcodeIndexRoute
 }
 export interface FileRouteTypes {
@@ -101,7 +120,9 @@ export interface FileRouteTypes {
     | '/currencies/create'
     | '/integrations/create'
     | '/currencies/'
+    | '/integrations/'
     | '/currencies/$shortcode/manage'
+    | '/integrations/$integrationId/manage'
     | '/currencies/$shortcode/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -111,7 +132,9 @@ export interface FileRouteTypes {
     | '/currencies/create'
     | '/integrations/create'
     | '/currencies'
+    | '/integrations'
     | '/currencies/$shortcode/manage'
+    | '/integrations/$integrationId/manage'
     | '/currencies/$shortcode'
   id:
     | '__root__'
@@ -121,7 +144,9 @@ export interface FileRouteTypes {
     | '/currencies/create'
     | '/integrations/create'
     | '/currencies/'
+    | '/integrations/'
     | '/currencies/$shortcode/manage'
+    | '/integrations/$integrationId/manage'
     | '/currencies/$shortcode/'
   fileRoutesById: FileRoutesById
 }
@@ -132,7 +157,9 @@ export interface RootRouteChildren {
   CurrenciesCreateRoute: typeof CurrenciesCreateRoute
   IntegrationsCreateRoute: typeof IntegrationsCreateRoute
   CurrenciesIndexRoute: typeof CurrenciesIndexRoute
+  IntegrationsIndexRoute: typeof IntegrationsIndexRoute
   CurrenciesShortcodeManageRoute: typeof CurrenciesShortcodeManageRoute
+  IntegrationsIntegrationIdManageRoute: typeof IntegrationsIntegrationIdManageRoute
   CurrenciesShortcodeIndexRoute: typeof CurrenciesShortcodeIndexRoute
 }
 
@@ -143,6 +170,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/integrations/': {
+      id: '/integrations/'
+      path: '/integrations'
+      fullPath: '/integrations/'
+      preLoaderRoute: typeof IntegrationsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/currencies/': {
@@ -187,6 +221,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CurrenciesShortcodeIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/integrations/$integrationId/manage': {
+      id: '/integrations/$integrationId/manage'
+      path: '/integrations/$integrationId/manage'
+      fullPath: '/integrations/$integrationId/manage'
+      preLoaderRoute: typeof IntegrationsIntegrationIdManageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/currencies/$shortcode/manage': {
       id: '/currencies/$shortcode/manage'
       path: '/currencies/$shortcode/manage'
@@ -204,7 +245,9 @@ const rootRouteChildren: RootRouteChildren = {
   CurrenciesCreateRoute: CurrenciesCreateRoute,
   IntegrationsCreateRoute: IntegrationsCreateRoute,
   CurrenciesIndexRoute: CurrenciesIndexRoute,
+  IntegrationsIndexRoute: IntegrationsIndexRoute,
   CurrenciesShortcodeManageRoute: CurrenciesShortcodeManageRoute,
+  IntegrationsIntegrationIdManageRoute: IntegrationsIntegrationIdManageRoute,
   CurrenciesShortcodeIndexRoute: CurrenciesShortcodeIndexRoute,
 }
 export const routeTree = rootRouteImport

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -47,6 +47,11 @@ function RootComponent() {
             </NavbarBrand>
             <NavbarContent justify="end">
               <NavbarItem>
+                <Link to="/integrations" color="foreground">
+                  Integrations
+                </Link>
+              </NavbarItem>
+              <NavbarItem>
                 <Link to="/currencies" color="foreground">
                   Currencies
                 </Link>

--- a/frontend/src/routes/integrations/$integrationId/manage.tsx
+++ b/frontend/src/routes/integrations/$integrationId/manage.tsx
@@ -202,12 +202,12 @@ function ManageTokens({ integrationId }: { integrationId: string }) {
         pathParams: { integrationId },
         body: value,
       });
+      setNewTokenValue(result.token);
       setShowCreateForm(false);
       form.reset();
       await queryClient.invalidateQueries(
         listIntegrationTokensQuery({ pathParams: { integrationId } }),
       );
-      setNewTokenValue(result.token);
     } catch (error) {
       form.setErrorMap({
         onSubmit: {

--- a/frontend/src/routes/integrations/$integrationId/manage.tsx
+++ b/frontend/src/routes/integrations/$integrationId/manage.tsx
@@ -271,13 +271,7 @@ function ManageTokens({ integrationId }: { integrationId: string }) {
       >
         <ModalContent>
           <ModalHeader>Create Token</ModalHeader>
-          <Form
-            onSubmit={(e) => {
-              e.preventDefault();
-              form.handleSubmit();
-            }}
-          >
-            <ModalBody>
+          <ModalBody>
               <form.Field
                 name="name"
                 children={(field) => (
@@ -305,21 +299,20 @@ function ManageTokens({ integrationId }: { integrationId: string }) {
                   errors.length > 0 && <Alert color="danger">{errors}</Alert>
                 }
               />
-            </ModalBody>
-            <ModalFooter>
-              <Button
-                onPress={() => {
-                  setCreateModalOpen(false);
-                  form.reset();
-                }}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" isLoading={isPending}>
-                Create
-              </Button>
-            </ModalFooter>
-          </Form>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              onPress={() => {
+                setCreateModalOpen(false);
+                form.reset();
+              }}
+            >
+              Cancel
+            </Button>
+            <Button isLoading={isPending} onPress={() => form.handleSubmit()}>
+              Create
+            </Button>
+          </ModalFooter>
         </ModalContent>
       </Modal>
 

--- a/frontend/src/routes/integrations/$integrationId/manage.tsx
+++ b/frontend/src/routes/integrations/$integrationId/manage.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/integrations/$integrationId/manage')({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { integrationId } = Route.useParams();
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold">Integration Management</h1>
+      <p>Integration ID: {integrationId}</p>
+    </div>
+  );
+}

--- a/frontend/src/routes/integrations/$integrationId/manage.tsx
+++ b/frontend/src/routes/integrations/$integrationId/manage.tsx
@@ -271,13 +271,13 @@ function ManageTokens({ integrationId }: { integrationId: string }) {
       >
         <ModalContent>
           <ModalHeader>Create Token</ModalHeader>
-          <ModalBody>
-            <Form
-              onSubmit={(e) => {
-                e.preventDefault();
-                form.handleSubmit();
-              }}
-            >
+          <Form
+            onSubmit={(e) => {
+              e.preventDefault();
+              form.handleSubmit();
+            }}
+          >
+            <ModalBody>
               <form.Field
                 name="name"
                 children={(field) => (
@@ -297,9 +297,6 @@ function ManageTokens({ integrationId }: { integrationId: string }) {
                   />
                 )}
               />
-              <Button type="submit" isLoading={isPending}>
-                Create
-              </Button>
               <form.Subscribe
                 selector={(state) =>
                   state.errors.filter((e) => typeof e === 'string')
@@ -308,18 +305,21 @@ function ManageTokens({ integrationId }: { integrationId: string }) {
                   errors.length > 0 && <Alert color="danger">{errors}</Alert>
                 }
               />
-            </Form>
-          </ModalBody>
-          <ModalFooter>
-            <Button
-              onPress={() => {
-                setCreateModalOpen(false);
-                form.reset();
-              }}
-            >
-              Cancel
-            </Button>
-          </ModalFooter>
+            </ModalBody>
+            <ModalFooter>
+              <Button
+                onPress={() => {
+                  setCreateModalOpen(false);
+                  form.reset();
+                }}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" isLoading={isPending}>
+                Create
+              </Button>
+            </ModalFooter>
+          </Form>
         </ModalContent>
       </Modal>
 

--- a/frontend/src/routes/integrations/$integrationId/manage.tsx
+++ b/frontend/src/routes/integrations/$integrationId/manage.tsx
@@ -1,16 +1,340 @@
+import { Alert, Button, Form, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from '@heroui/react';
+import { useForm } from '@tanstack/react-form';
 import { createFileRoute } from '@tanstack/react-router';
+import { useState } from 'react';
+import z from 'zod';
+
+import { queryClient } from '@/lib/query';
+import {
+  getIntegrationQuery,
+  listIntegrationTokensQuery,
+  useCreateIntegrationToken,
+  useDeleteIntegrationToken,
+  useEditIntegration,
+  useSuspenseGetIntegration,
+  useSuspenseListIntegrationTokens,
+} from '@/queries/internal/internalComponents';
+import type {
+  ErrorResponseSchema,
+  IntegrationTokenSchema,
+} from '@/queries/internal/internalSchemas';
+import {
+  CreateIntegrationTokenSchemaZod,
+  EditIntegrationSchemaZod,
+} from '@/queries/internal/internalSchemas.zod';
 
 export const Route = createFileRoute('/integrations/$integrationId/manage')({
   component: RouteComponent,
+  loader: ({ params: { integrationId } }) =>
+    Promise.all([
+      queryClient.ensureQueryData(
+        getIntegrationQuery({ pathParams: { integrationId } }),
+      ),
+      queryClient.ensureQueryData(
+        listIntegrationTokensQuery({ pathParams: { integrationId } }),
+      ),
+    ]),
 });
+
+function EditIntegrationDetails({ integrationId }: { integrationId: string }) {
+  const { data: integration } = useSuspenseGetIntegration({
+    pathParams: { integrationId },
+  });
+  const { mutateAsync: editIntegration, isPending, data } = useEditIntegration();
+
+  async function handleSubmit(
+    value: z.infer<typeof EditIntegrationSchemaZod>,
+  ) {
+    try {
+      await editIntegration({ pathParams: { integrationId }, body: value });
+      await queryClient.invalidateQueries(
+        getIntegrationQuery({ pathParams: { integrationId } }),
+      );
+    } catch (error) {
+      form.setErrorMap({
+        onSubmit: {
+          fields: {},
+          form: (error as ErrorResponseSchema).detail,
+        },
+      });
+    }
+  }
+
+  const form = useForm({
+    defaultValues: {
+      name: integration.name,
+      description: integration.description,
+      url: integration.url ?? '',
+    } as z.infer<typeof EditIntegrationSchemaZod>,
+    onSubmit: ({ value }) => handleSubmit(value),
+    validators: { onSubmit: EditIntegrationSchemaZod },
+  });
+
+  return (
+    <div>
+      <h2 className="text-2xl font-semibold">Edit Integration Details</h2>
+      <Form
+        onSubmit={(e) => {
+          e.preventDefault();
+          form.handleSubmit();
+        }}
+      >
+        <form.Field
+          name="name"
+          children={(field) => (
+            <Input
+              name={field.name}
+              isRequired
+              label="Name"
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+              validationBehavior="aria"
+              errorMessage={field.state.meta.errors
+                .filter((e) => e !== undefined)
+                .map((e) => e.message)
+                .join(', ')}
+              isInvalid={!field.state.meta.isValid}
+            />
+          )}
+        />
+        <form.Field
+          name="description"
+          children={(field) => (
+            <Input
+              name={field.name}
+              isRequired
+              label="Description"
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+              validationBehavior="aria"
+              errorMessage={field.state.meta.errors
+                .filter((e) => e !== undefined)
+                .map((e) => e.message)
+                .join(', ')}
+              isInvalid={!field.state.meta.isValid}
+            />
+          )}
+        />
+        <form.Field
+          name="url"
+          children={(field) => (
+            <Input
+              name={field.name}
+              label="URL"
+              value={field.state.value || ''}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+              validationBehavior="aria"
+              errorMessage={field.state.meta.errors
+                .filter((e) => e !== undefined)
+                .map((e) => e.message)
+                .join(', ')}
+              isInvalid={!field.state.meta.isValid}
+            />
+          )}
+        />
+        <Button type="submit" isLoading={isPending}>
+          Save
+        </Button>
+        <form.Subscribe
+          selector={(state) => state.errors.filter((e) => typeof e === 'string')}
+          children={(errors) =>
+            errors.length > 0 && <Alert color="danger">{errors}</Alert>
+          }
+        />
+        {data && <Alert color="success">Integration updated!</Alert>}
+      </Form>
+    </div>
+  );
+}
+
+function TokenRow({
+  token,
+  integrationId,
+  onDeleteError,
+}: {
+  token: IntegrationTokenSchema;
+  integrationId: string;
+  onDeleteError: (message: string) => void;
+}) {
+  const { mutateAsync: deleteToken } = useDeleteIntegrationToken();
+
+  async function handleDelete() {
+    try {
+      await deleteToken({
+        pathParams: { integrationId, tokenId: token.id },
+      });
+      await queryClient.invalidateQueries(
+        listIntegrationTokensQuery({ pathParams: { integrationId } }),
+      );
+    } catch (error) {
+      onDeleteError((error as ErrorResponseSchema).detail);
+    }
+  }
+
+  return (
+    <div className="flex w-full items-center justify-between">
+      <span>{token.name}</span>
+      <Button color="danger" onPress={handleDelete}>
+        Delete
+      </Button>
+    </div>
+  );
+}
+
+function ManageTokens({ integrationId }: { integrationId: string }) {
+  const { data: tokens } = useSuspenseListIntegrationTokens({
+    pathParams: { integrationId },
+  });
+  const { mutateAsync: createToken, isPending } = useCreateIntegrationToken();
+
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newTokenValue, setNewTokenValue] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  async function handleCreateSubmit(
+    value: z.infer<typeof CreateIntegrationTokenSchemaZod>,
+  ) {
+    try {
+      const result = await createToken({
+        pathParams: { integrationId },
+        body: value,
+      });
+      setShowCreateForm(false);
+      form.reset();
+      await queryClient.invalidateQueries(
+        listIntegrationTokensQuery({ pathParams: { integrationId } }),
+      );
+      setNewTokenValue(result.token);
+    } catch (error) {
+      form.setErrorMap({
+        onSubmit: {
+          fields: {},
+          form: (error as ErrorResponseSchema).detail,
+        },
+      });
+    }
+  }
+
+  const form = useForm({
+    defaultValues: { name: '' } as z.infer<
+      typeof CreateIntegrationTokenSchemaZod
+    >,
+    onSubmit: ({ value }) => handleCreateSubmit(value),
+    validators: { onSubmit: CreateIntegrationTokenSchemaZod },
+  });
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-2xl font-semibold">Manage Tokens</h2>
+
+      {deleteError && (
+        <Alert color="danger" onClose={() => setDeleteError(null)}>
+          {deleteError}
+        </Alert>
+      )}
+
+      <div className="space-y-1">
+        {tokens.length === 0 ? (
+          <p className="text-default-400 w-full text-center italic">
+            No tokens yet.
+          </p>
+        ) : (
+          tokens.map((token) => (
+            <TokenRow
+              key={token.id}
+              token={token}
+              integrationId={integrationId}
+              onDeleteError={setDeleteError}
+            />
+          ))
+        )}
+      </div>
+
+      <Button
+        onPress={() => {
+          setShowCreateForm((v) => !v);
+          form.reset();
+        }}
+      >
+        Create Token
+      </Button>
+
+      {showCreateForm && (
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+            form.handleSubmit();
+          }}
+        >
+          <form.Field
+            name="name"
+            children={(field) => (
+              <Input
+                name={field.name}
+                isRequired
+                label="Token Name"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+                validationBehavior="aria"
+                errorMessage={field.state.meta.errors
+                  .filter((e) => e !== undefined)
+                  .map((e) => e.message)
+                  .join(', ')}
+                isInvalid={!field.state.meta.isValid}
+              />
+            )}
+          />
+          <Button type="submit" isLoading={isPending}>
+            Create
+          </Button>
+          <form.Subscribe
+            selector={(state) =>
+              state.errors.filter((e) => typeof e === 'string')
+            }
+            children={(errors) =>
+              errors.length > 0 && <Alert color="danger">{errors}</Alert>
+            }
+          />
+        </Form>
+      )}
+
+      <Modal
+        isOpen={newTokenValue !== null}
+        onClose={() => setNewTokenValue(null)}
+      >
+        <ModalContent>
+          <ModalHeader>Token Created</ModalHeader>
+          <ModalBody>
+            <Alert color="warning">
+              This token will not be shown again. Copy it now.
+            </Alert>
+            <Input
+              isReadOnly
+              label="Token"
+              value={newTokenValue ?? ''}
+              onClick={(e) => (e.target as HTMLInputElement).select()}
+            />
+          </ModalBody>
+          <ModalFooter>
+            <Button onPress={() => setNewTokenValue(null)}>Done</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+}
 
 function RouteComponent() {
   const { integrationId } = Route.useParams();
 
   return (
-    <div>
-      <h1 className="text-xl font-bold">Integration Management</h1>
-      <p>Integration ID: {integrationId}</p>
+    <div className="space-y-8">
+      <EditIntegrationDetails integrationId={integrationId} />
+      <ManageTokens integrationId={integrationId} />
     </div>
   );
 }

--- a/frontend/src/routes/integrations/$integrationId/manage.tsx
+++ b/frontend/src/routes/integrations/$integrationId/manage.tsx
@@ -190,7 +190,7 @@ function ManageTokens({ integrationId }: { integrationId: string }) {
   });
   const { mutateAsync: createToken, isPending } = useCreateIntegrationToken();
 
-  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [createModalOpen, setCreateModalOpen] = useState(false);
   const [newTokenValue, setNewTokenValue] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
@@ -202,9 +202,9 @@ function ManageTokens({ integrationId }: { integrationId: string }) {
         pathParams: { integrationId },
         body: value,
       });
-      setNewTokenValue(result.token);
-      setShowCreateForm(false);
+      setCreateModalOpen(false);
       form.reset();
+      setNewTokenValue(result.token);
       await queryClient.invalidateQueries(
         listIntegrationTokensQuery({ pathParams: { integrationId } }),
       );
@@ -255,52 +255,73 @@ function ManageTokens({ integrationId }: { integrationId: string }) {
 
       <Button
         onPress={() => {
-          setShowCreateForm((v) => !v);
+          setCreateModalOpen(true);
           form.reset();
         }}
       >
         Create Token
       </Button>
 
-      {showCreateForm && (
-        <Form
-          onSubmit={(e) => {
-            e.preventDefault();
-            form.handleSubmit();
-          }}
-        >
-          <form.Field
-            name="name"
-            children={(field) => (
-              <Input
-                name={field.name}
-                isRequired
-                label="Token Name"
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-                validationBehavior="aria"
-                errorMessage={field.state.meta.errors
-                  .filter((e) => e !== undefined)
-                  .map((e) => e.message)
-                  .join(', ')}
-                isInvalid={!field.state.meta.isValid}
+      <Modal
+        isOpen={createModalOpen}
+        onClose={() => {
+          setCreateModalOpen(false);
+          form.reset();
+        }}
+      >
+        <ModalContent>
+          <ModalHeader>Create Token</ModalHeader>
+          <ModalBody>
+            <Form
+              onSubmit={(e) => {
+                e.preventDefault();
+                form.handleSubmit();
+              }}
+            >
+              <form.Field
+                name="name"
+                children={(field) => (
+                  <Input
+                    name={field.name}
+                    isRequired
+                    label="Token Name"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    validationBehavior="aria"
+                    errorMessage={field.state.meta.errors
+                      .filter((e) => e !== undefined)
+                      .map((e) => e.message)
+                      .join(', ')}
+                    isInvalid={!field.state.meta.isValid}
+                  />
+                )}
               />
-            )}
-          />
-          <Button type="submit" isLoading={isPending}>
-            Create
-          </Button>
-          <form.Subscribe
-            selector={(state) =>
-              state.errors.filter((e) => typeof e === 'string')
-            }
-            children={(errors) =>
-              errors.length > 0 && <Alert color="danger">{errors}</Alert>
-            }
-          />
-        </Form>
-      )}
+              <Button type="submit" isLoading={isPending}>
+                Create
+              </Button>
+              <form.Subscribe
+                selector={(state) =>
+                  state.errors.filter((e) => typeof e === 'string')
+                }
+                children={(errors) =>
+                  errors.length > 0 && <Alert color="danger">{errors}</Alert>
+                }
+              />
+            </Form>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              onPress={() => {
+                setCreateModalOpen(false);
+                form.reset();
+              }}
+            >
+              Cancel
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
 
       <Modal
         isOpen={newTokenValue !== null}

--- a/frontend/src/routes/integrations/create.tsx
+++ b/frontend/src/routes/integrations/create.tsx
@@ -28,6 +28,7 @@ function CreateIntegrationForm() {
       );
       navigate({ to: '/integrations' });
     } catch (error) {
+      // TODO: Better, re-usable error handling
       form.setErrorMap({ onSubmit: { fields: {}, form: (error as ErrorResponseSchema).detail } });
     }
   }

--- a/frontend/src/routes/integrations/create.tsx
+++ b/frontend/src/routes/integrations/create.tsx
@@ -1,10 +1,14 @@
 import { Alert, Button, Form, Input } from '@heroui/react';
 import { useForm } from '@tanstack/react-form';
-import { Link, createFileRoute } from '@tanstack/react-router';
+import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 import z from 'zod';
 
+import { queryClient } from '@/lib/query';
 import { useStore } from '@/lib/state';
-import { useCreateIntegration } from '@/queries/internal/internalComponents';
+import {
+  listIntegrationsQuery,
+  useCreateIntegration,
+} from '@/queries/internal/internalComponents';
 import { ErrorResponseSchema } from '@/queries/internal/internalSchemas';
 import { CreateIntegrationSchemaZod } from '@/queries/internal/internalSchemas.zod';
 
@@ -13,13 +17,17 @@ export const Route = createFileRoute('/integrations/create')({
 });
 
 function CreateIntegrationForm() {
-  const { mutateAsync: createIntegration, isPending, data } = useCreateIntegration();
+  const { mutateAsync: createIntegration, isPending } = useCreateIntegration();
+  const navigate = useNavigate();
 
   async function handleSubmit(value: z.infer<typeof CreateIntegrationSchemaZod>) {
     try {
       await createIntegration({ body: value });
+      await queryClient.invalidateQueries(
+        listIntegrationsQuery({ queryParams: { manageable: true } }),
+      );
+      navigate({ to: '/integrations' });
     } catch (error) {
-      // TODO: Better, re-usable error handling
       form.setErrorMap({ onSubmit: { fields: {}, form: (error as ErrorResponseSchema).detail } });
     }
   }
@@ -107,8 +115,6 @@ function CreateIntegrationForm() {
         selector={(state) => state.errors.filter((e) => typeof e === 'string')}
         children={(errors) => errors.length > 0 && <Alert color="danger">{errors}</Alert>}
       />
-
-      {data && <Alert color="success">Integration created!</Alert>}
     </Form>
   );
 }

--- a/frontend/src/routes/integrations/index.tsx
+++ b/frontend/src/routes/integrations/index.tsx
@@ -1,0 +1,61 @@
+import { Button } from '@heroui/react';
+import { createFileRoute } from '@tanstack/react-router';
+
+import { Link } from '@/components/link';
+import { queryClient } from '@/lib/query';
+import { useStore } from '@/lib/state';
+import {
+  listIntegrationsQuery,
+  useSuspenseListIntegrations,
+} from '@/queries/internal/internalComponents';
+
+export const Route = createFileRoute('/integrations/')({
+  component: RouteComponent,
+  loader: () =>
+    queryClient.ensureQueryData(
+      listIntegrationsQuery({ queryParams: { manageable: true } }),
+    ),
+});
+
+function RouteComponent() {
+  const { data: integrations } = useSuspenseListIntegrations({
+    queryParams: { manageable: true },
+  });
+  const user = useStore((state) => state.user);
+
+  return (
+    <div>
+      <div className="flex flex-row justify-between">
+        <h1 className="text-xl font-bold">Integrations</h1>
+        {user && (
+          <Button as={Link} to="/integrations/create">
+            Create Integration
+          </Button>
+        )}
+      </div>
+      <div>
+        {integrations.map((integration) => (
+          <div key={integration.id}>
+            <Link
+              to="/integrations/$integrationId/manage"
+              params={{ integrationId: integration.id }}
+              color="foreground"
+            >
+              <span className="font-semibold">{integration.name}</span>
+              {integration.description && (
+                <span className="text-default-500 ml-2 text-sm">
+                  {integration.description}
+                </span>
+              )}
+            </Link>
+          </div>
+        ))}
+        {integrations.length === 0 && (
+          <p className="text-default-400 w-full text-center italic">
+            No integrations yet.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/hyperioncs/api/app/routers/integrations.py
+++ b/hyperioncs/api/app/routers/integrations.py
@@ -1,5 +1,4 @@
 import jwt
-
 from fastapi import APIRouter, Depends, Query, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import and_, not_, or_, select

--- a/hyperioncs/api/app/routers/integrations.py
+++ b/hyperioncs/api/app/routers/integrations.py
@@ -75,54 +75,29 @@ async def create_integration(
 
 @integrations_router.get("/", response_model=list[IntegrationSchema])
 async def list_integrations(
-    manageable: bool = Query(False),
+    manageable: bool = Query(
+        False,
+        description="When true, returns only integrations the user can edit. Otherwise returns public integrations and integrations the user can connect.",
+    ),
     db: AsyncSession = Depends(get_db),
     current_user: SessionUser = Depends(require_session_user),
 ):
-    """List integrations visible to the current user.
-
-    When manageable=true, returns only integrations the user can edit.
-    Otherwise returns public integrations and integrations the user can connect.
-    """
-    if manageable:
-        return (
-            (
-                await db.execute(
-                    select(Integration).join(
-                        IntegrationPermission,
-                        and_(
-                            IntegrationPermission.user_id == current_user.id,
-                            IntegrationPermission.integration_id == Integration.id,
-                            IntegrationPermission.role.in_(IntegrationActionRoles.Edit),
-                        ),
-                    )
-                )
-            )
-            .scalars()
-            .all()
-        )
-
-    return (
-        (
-            await db.execute(
-                select(Integration)
-                .join(
-                    IntegrationPermission,
-                    and_(
-                        IntegrationPermission.user_id == current_user.id,
-                        IntegrationPermission.integration_id == Integration.id,
-                        IntegrationPermission.role.in_(IntegrationActionRoles.Connect),
-                    ),
-                    isouter=True,
-                )
-                .filter(
-                    or_(not_(Integration.private), IntegrationPermission.id.isnot(None))
-                )
-            )
-        )
-        .scalars()
-        .all()
+    """List integrations visible to the current user."""
+    roles = IntegrationActionRoles.Edit if manageable else IntegrationActionRoles.Connect
+    query = select(Integration).join(
+        IntegrationPermission,
+        and_(
+            IntegrationPermission.user_id == current_user.id,
+            IntegrationPermission.integration_id == Integration.id,
+            IntegrationPermission.role.in_(roles),
+        ),
+        isouter=not manageable,
     )
+    if not manageable:
+        query = query.filter(
+            or_(not_(Integration.private), IntegrationPermission.id.isnot(None))
+        )
+    return (await db.execute(query)).scalars().all()
 
 
 @integrations_router.get(
@@ -140,11 +115,7 @@ async def get_integration(
     db: AsyncSession = Depends(get_db),
     current_user: SessionUser = Depends(require_session_user),
 ):
-    """Get a single integration visible to the current user.
-
-    Public integrations are accessible to all authenticated users.
-    Private integrations require the View role.
-    """
+    """Get a single integration visible to the current user."""
     integration = (
         await db.execute(
             select(Integration)
@@ -191,7 +162,7 @@ async def edit_integration(
     db: AsyncSession = Depends(get_db),
     current_user: SessionUser = Depends(require_session_user),
 ):
-    """Edit an integration's metadata. Requires Edit role."""
+    """Edit an integration's metadata."""
     async with db.begin():
         integration = (
             await db.execute(
@@ -240,7 +211,7 @@ async def list_integration_tokens(
     db: AsyncSession = Depends(get_db),
     current_user: SessionUser = Depends(require_session_user),
 ):
-    """List tokens for an integration. Requires Edit role."""
+    """List tokens for an integration."""
     integration = (
         await db.execute(
             select(Integration)
@@ -292,7 +263,7 @@ async def create_integration_token(
     db: AsyncSession = Depends(get_db),
     current_user: SessionUser = Depends(require_session_user),
 ):
-    """Create a new token for an integration. Requires Edit role.
+    """Create a new token for an integration.
 
     The token value is only returned in this response — it cannot be retrieved later.
     """
@@ -362,7 +333,7 @@ async def delete_integration_token(
     db: AsyncSession = Depends(get_db),
     current_user: SessionUser = Depends(require_session_user),
 ):
-    """Delete an integration token. Requires Edit role."""
+    """Delete an integration token."""
     async with db.begin():
         integration = (
             await db.execute(

--- a/hyperioncs/api/app/routers/integrations.py
+++ b/hyperioncs/api/app/routers/integrations.py
@@ -1,3 +1,5 @@
+import jwt
+
 from fastapi import APIRouter, Depends, Query, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import and_, not_, or_, select
@@ -6,8 +8,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from hyperioncs.api.app.schemas.integrations import (
     ConnectIntegrationSchema,
     CreateIntegrationSchema,
+    CreateIntegrationTokenSchema,
     EditIntegrationSchema,
 )
+from hyperioncs.config import config
 from hyperioncs.db.models.currency import Currency
 from hyperioncs.db.models.currency_permission import (
     CurrencyActionRoles,
@@ -20,11 +24,16 @@ from hyperioncs.db.models.integration_permission import (
     IntegrationPermission,
     IntegrationRole,
 )
+from hyperioncs.db.models.integration_token import IntegrationToken
 from hyperioncs.db.models.utils import default_uuid_str
 from hyperioncs.dependencies.auth import require_session_user
 from hyperioncs.dependencies.database import get_db
 from hyperioncs.schemas import ErrorResponseSchema
-from hyperioncs.schemas.integrations import IntegrationSchema
+from hyperioncs.schemas.integrations import (
+    CreatedIntegrationTokenSchema,
+    IntegrationSchema,
+    IntegrationTokenSchema,
+)
 from hyperioncs.schemas.user import SessionUser
 
 integrations_router = APIRouter(tags=["Integrations"])
@@ -215,6 +224,190 @@ async def edit_integration(
         await db.commit()
 
         return integration
+
+
+@integrations_router.get(
+    "/{integration_id}/tokens",
+    response_model=list[IntegrationTokenSchema],
+    responses={
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Unauthorized",
+            "model": ErrorResponseSchema,
+        }
+    },
+)
+async def list_integration_tokens(
+    integration_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: SessionUser = Depends(require_session_user),
+):
+    """List tokens for an integration. Requires Edit role."""
+    integration = (
+        await db.execute(
+            select(Integration)
+            .filter_by(id=integration_id)
+            .join(
+                IntegrationPermission,
+                and_(
+                    IntegrationPermission.user_id == current_user.id,
+                    IntegrationPermission.integration_id == Integration.id,
+                    IntegrationPermission.role.in_(IntegrationActionRoles.Edit),
+                ),
+            )
+        )
+    ).scalar_one_or_none()
+
+    if not integration:
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content=ErrorResponseSchema(
+                detail="The requested integration could not be found or you do not have permission to manage its tokens."
+            ).model_dump(),
+        )
+
+    return (
+        (
+            await db.execute(
+                select(IntegrationToken).filter_by(integration_id=integration.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+@integrations_router.post(
+    "/{integration_id}/tokens",
+    status_code=status.HTTP_201_CREATED,
+    response_model=CreatedIntegrationTokenSchema,
+    responses={
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Unauthorized",
+            "model": ErrorResponseSchema,
+        }
+    },
+)
+async def create_integration_token(
+    integration_id: str,
+    body: CreateIntegrationTokenSchema,
+    db: AsyncSession = Depends(get_db),
+    current_user: SessionUser = Depends(require_session_user),
+):
+    """Create a new token for an integration. Requires Edit role.
+
+    The token value is only returned in this response — it cannot be retrieved later.
+    """
+    async with db.begin():
+        integration = (
+            await db.execute(
+                select(Integration)
+                .filter_by(id=integration_id)
+                .join(
+                    IntegrationPermission,
+                    and_(
+                        IntegrationPermission.user_id == current_user.id,
+                        IntegrationPermission.integration_id == Integration.id,
+                        IntegrationPermission.role.in_(IntegrationActionRoles.Edit),
+                    ),
+                )
+            )
+        ).scalar_one_or_none()
+
+        if not integration:
+            return JSONResponse(
+                status_code=status.HTTP_403_FORBIDDEN,
+                content=ErrorResponseSchema(
+                    detail="The requested integration could not be found or you do not have permission to manage its tokens."
+                ).model_dump(),
+            )
+
+        token_id = default_uuid_str()
+        new_token = IntegrationToken(
+            id=token_id,
+            integration_id=integration.id,
+            name=body.name,
+        )
+        db.add(new_token)
+        await db.commit()
+
+    token_value = jwt.encode(
+        {"token_id": token_id},
+        config.jwt_secret,
+        algorithm=config.jwt_algorithm,
+    )
+
+    return CreatedIntegrationTokenSchema(
+        id=token_id,
+        name=body.name,
+        token=token_value,
+    )
+
+
+@integrations_router.delete(
+    "/{integration_id}/tokens/{token_id}",
+    status_code=status.HTTP_202_ACCEPTED,
+    responses={
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Unauthorized",
+            "model": ErrorResponseSchema,
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Token Not Found",
+            "model": ErrorResponseSchema,
+        },
+    },
+)
+async def delete_integration_token(
+    integration_id: str,
+    token_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: SessionUser = Depends(require_session_user),
+):
+    """Delete an integration token. Requires Edit role."""
+    async with db.begin():
+        integration = (
+            await db.execute(
+                select(Integration)
+                .filter_by(id=integration_id)
+                .join(
+                    IntegrationPermission,
+                    and_(
+                        IntegrationPermission.user_id == current_user.id,
+                        IntegrationPermission.integration_id == Integration.id,
+                        IntegrationPermission.role.in_(IntegrationActionRoles.Edit),
+                    ),
+                )
+            )
+        ).scalar_one_or_none()
+
+        if not integration:
+            return JSONResponse(
+                status_code=status.HTTP_403_FORBIDDEN,
+                content=ErrorResponseSchema(
+                    detail="The requested integration could not be found or you do not have permission to manage its tokens."
+                ).model_dump(),
+            )
+
+        token = (
+            await db.execute(
+                select(IntegrationToken).filter_by(
+                    id=token_id, integration_id=integration.id
+                )
+            )
+        ).scalar_one_or_none()
+
+        if not token:
+            return JSONResponse(
+                status_code=status.HTTP_404_NOT_FOUND,
+                content=ErrorResponseSchema(
+                    detail="The requested token could not be found."
+                ).model_dump(),
+            )
+
+        await db.delete(token)
+        await db.commit()
+
+    return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content={})
 
 
 # TODO: Should this and the disconnect endpoint be made more restful?

--- a/hyperioncs/api/app/routers/integrations.py
+++ b/hyperioncs/api/app/routers/integrations.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from hyperioncs.api.app.schemas.integrations import (
     ConnectIntegrationSchema,
     CreateIntegrationSchema,
+    EditIntegrationSchema,
 )
 from hyperioncs.db.models.currency import Currency
 from hyperioncs.db.models.currency_permission import (
@@ -164,6 +165,56 @@ async def get_integration(
         )
 
     return integration
+
+
+@integrations_router.patch(
+    "/{integration_id}",
+    response_model=IntegrationSchema,
+    responses={
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Unauthorized",
+            "model": ErrorResponseSchema,
+        }
+    },
+)
+async def edit_integration(
+    integration_id: str,
+    body: EditIntegrationSchema,
+    db: AsyncSession = Depends(get_db),
+    current_user: SessionUser = Depends(require_session_user),
+):
+    """Edit an integration's metadata. Requires Edit role."""
+    async with db.begin():
+        integration = (
+            await db.execute(
+                select(Integration)
+                .filter_by(id=integration_id)
+                .join(
+                    IntegrationPermission,
+                    and_(
+                        IntegrationPermission.user_id == current_user.id,
+                        IntegrationPermission.integration_id == Integration.id,
+                        IntegrationPermission.role.in_(IntegrationActionRoles.Edit),
+                    ),
+                )
+            )
+        ).scalar_one_or_none()
+
+        if not integration:
+            return JSONResponse(
+                status_code=status.HTTP_403_FORBIDDEN,
+                content=ErrorResponseSchema(
+                    detail="The requested integration could not be found or you do not have permission to edit it."
+                ).model_dump(),
+            )
+
+        integration.name = body.name
+        integration.description = body.description
+        integration.url = body.url
+
+        await db.commit()
+
+        return integration
 
 
 # TODO: Should this and the disconnect endpoint be made more restful?

--- a/hyperioncs/api/app/routers/integrations.py
+++ b/hyperioncs/api/app/routers/integrations.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Query, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import and_, not_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -66,10 +66,33 @@ async def create_integration(
 
 @integrations_router.get("/", response_model=list[IntegrationSchema])
 async def list_integrations(
+    manageable: bool = Query(False),
     db: AsyncSession = Depends(get_db),
     current_user: SessionUser = Depends(require_session_user),
 ):
-    """List all integrations the current user has access to."""
+    """List integrations visible to the current user.
+
+    When manageable=true, returns only integrations the user can edit.
+    Otherwise returns public integrations and integrations the user can connect.
+    """
+    if manageable:
+        return (
+            (
+                await db.execute(
+                    select(Integration).join(
+                        IntegrationPermission,
+                        and_(
+                            IntegrationPermission.user_id == current_user.id,
+                            IntegrationPermission.integration_id == Integration.id,
+                            IntegrationPermission.role.in_(IntegrationActionRoles.Edit),
+                        ),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
     return (
         (
             await db.execute(

--- a/hyperioncs/api/app/routers/integrations.py
+++ b/hyperioncs/api/app/routers/integrations.py
@@ -116,6 +116,56 @@ async def list_integrations(
     )
 
 
+@integrations_router.get(
+    "/{integration_id}",
+    response_model=IntegrationSchema,
+    responses={
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Unauthorized",
+            "model": ErrorResponseSchema,
+        }
+    },
+)
+async def get_integration(
+    integration_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: SessionUser = Depends(require_session_user),
+):
+    """Get a single integration visible to the current user.
+
+    Public integrations are accessible to all authenticated users.
+    Private integrations require the View role.
+    """
+    integration = (
+        await db.execute(
+            select(Integration)
+            .filter_by(id=integration_id)
+            .join(
+                IntegrationPermission,
+                and_(
+                    IntegrationPermission.user_id == current_user.id,
+                    IntegrationPermission.integration_id == Integration.id,
+                    IntegrationPermission.role.in_(IntegrationActionRoles.View),
+                ),
+                isouter=True,
+            )
+            .filter(
+                or_(not_(Integration.private), IntegrationPermission.id.isnot(None))
+            )
+        )
+    ).scalar_one_or_none()
+
+    if not integration:
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content=ErrorResponseSchema(
+                detail="The requested integration could not be found or you do not have permission to view it."
+            ).model_dump(),
+        )
+
+    return integration
+
+
 # TODO: Should this and the disconnect endpoint be made more restful?
 # TODO: Can the permission logic between the two apis be deduplicated?
 @integrations_router.post(

--- a/hyperioncs/api/app/schemas/integrations.py
+++ b/hyperioncs/api/app/schemas/integrations.py
@@ -15,3 +15,13 @@ class ConnectIntegrationSchema(BaseModel):
     currency_shortcode: str = Field(
         description="The shortcode of the currency to connect the integration to."
     )
+
+
+class EditIntegrationSchema(BaseModel):
+    name: str = Field(description="The name of the integration.")
+    description: str = Field(description="A description of the integration.")
+    url: NullableString = Field(description="URL to the website for the integration.")
+
+
+class CreateIntegrationTokenSchema(BaseModel):
+    name: str = Field(description="The name of the token.")

--- a/hyperioncs/db/models/integration_permission.py
+++ b/hyperioncs/db/models/integration_permission.py
@@ -13,11 +13,13 @@ if TYPE_CHECKING:
 
 class IntegrationRole(enum.Enum):
     Owner = "owner"
+    View = "view"
 
 
 class IntegrationActionRoles:
     Edit = [IntegrationRole.Owner]
     Connect = [IntegrationRole.Owner]
+    View = [IntegrationRole.View, IntegrationRole.Owner]
 
 
 class IntegrationPermission(Base):

--- a/hyperioncs/db/models/integration_permission.py
+++ b/hyperioncs/db/models/integration_permission.py
@@ -13,13 +13,12 @@ if TYPE_CHECKING:
 
 class IntegrationRole(enum.Enum):
     Owner = "owner"
-    View = "view"
 
 
 class IntegrationActionRoles:
     Edit = [IntegrationRole.Owner]
     Connect = [IntegrationRole.Owner]
-    View = [IntegrationRole.View, IntegrationRole.Owner]
+    View = [IntegrationRole.Owner]
 
 
 class IntegrationPermission(Base):

--- a/hyperioncs/db/models/integration_token.py
+++ b/hyperioncs/db/models/integration_token.py
@@ -17,5 +17,6 @@ class IntegrationToken(Base):
     integration_id: Mapped[str] = mapped_column(
         ForeignKey("integrations.id", ondelete="CASCADE")
     )
+    name: Mapped[str]
 
     integration: Mapped["Integration"] = relationship(lazy="raise")

--- a/hyperioncs/migrations/versions/781cb27e06c3_create_integration_token_model.py
+++ b/hyperioncs/migrations/versions/781cb27e06c3_create_integration_token_model.py
@@ -23,6 +23,7 @@ def upgrade() -> None:
         "integration_tokens",
         sa.Column("id", sa.String(), nullable=False),
         sa.Column("integration_id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
         sa.ForeignKeyConstraint(
             ["integration_id"],
             ["integrations.id"],

--- a/hyperioncs/schemas/integrations.py
+++ b/hyperioncs/schemas/integrations.py
@@ -11,3 +11,18 @@ class IntegrationSchema(BaseModel):
         default=None, description="URL to the website for the integration."
     )
     private: bool = Field(description="Whether the integration is private.")
+
+
+class IntegrationTokenSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str = Field(description="The unique identifier of the token.")
+    name: str = Field(description="The name of the token.")
+
+
+class CreatedIntegrationTokenSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str = Field(description="The unique identifier of the token.")
+    name: str = Field(description="The name of the token.")
+    token: str = Field(description="The JWT token value. Only returned at creation time.")


### PR DESCRIPTION
## Summary

- Adds View role to IntegrationRole, allowing private integrations to be viewed without full Owner access
- Adds token name support and new backend endpoints: get, edit, list/create/delete tokens
- Adds integrations list page, management page (edit metadata + manage tokens with one-time JWT display), and redirects create page to list after success

## Test Plan

- [x] Navigate to `/integrations/` — should show list of manageable integrations with "Create Integration" button when logged in
- [x] Create an integration — should redirect to `/integrations/` and show it in the list
- [x] Click an integration → `/integrations/$id/manage` — edit name/description/url, verify save shows success alert
- [x] Create a token — modal appears with JWT value and warning; dismissing clears it (value not recoverable)
- [x] Delete a token — list updates immediately
- [x] Verify "Integrations" navbar link appears before "Currencies"